### PR TITLE
Grpc support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,10 @@ metrics-exporter-prometheus = "0"
 mime = "0.3.16"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-prost = "0.10.1"
+prost = "0.11.0"
 tokio = { version = "1.0", features = ["full"] }
 tokio-metrics = "0.1.0"
-tonic = "0.7.1"
+tonic = "0.8.0"
 tower = { version = "0.4", features = ["full"] }
 tower-http = { version = "0.3", features = ["full"] }
 tracing = "0.1"

--- a/examples/configuration/src/main.rs
+++ b/examples/configuration/src/main.rs
@@ -1,14 +1,14 @@
 use axum::routing::get;
 use axum::Router;
 
-use fregate::{Application, DefaultHealth, Environment};
+use fregate::{AlwaysHealthy, Application, Environment};
 
 #[tokio::main]
 async fn main() {
     std::env::set_var("APP_SERVER_HOST", "0.0.0.0");
     std::env::set_var("APP_SERVER_PORT", "8005");
 
-    let app = Application::builder::<DefaultHealth>()
+    let app = Application::builder::<AlwaysHealthy>()
         .init_tracing()
         .set_configuration_environment(Environment::Prefixed("APP"))
         .set_rest_routes(Router::new().route("/", get(handler)))

--- a/examples/health/Cargo.toml
+++ b/examples/health/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 fregate = { path = "../.." }
+async-trait = "0.1.57"
 axum  = '0.5.1'
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1.29"

--- a/examples/health/src/main.rs
+++ b/examples/health/src/main.rs
@@ -8,8 +8,9 @@ pub struct CustomHealth {
     status: AtomicU8,
 }
 
+#[async_trait::async_trait]
 impl Health for CustomHealth {
-    fn check(&self) -> HealthStatus {
+    async fn check(&self) -> HealthStatus {
         match self.status.fetch_add(1, Ordering::SeqCst) {
             0..=2 => HealthStatus::DOWN,
             _ => HealthStatus::UP,

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -1,11 +1,11 @@
 use axum::routing::get;
 use axum::Router;
 
-use fregate::{Application, DefaultHealth};
+use fregate::{AlwaysHealthy, Application};
 
 #[tokio::main]
 async fn main() {
-    let app = Application::builder::<DefaultHealth>()
+    let app = Application::builder::<AlwaysHealthy>()
         .init_tracing()
         .set_configuration_file("./src/resources/default_conf.toml")
         .set_rest_routes(Router::new().route("/", get(handler)))

--- a/examples/http-proxy/src/main.rs
+++ b/examples/http-proxy/src/main.rs
@@ -10,7 +10,7 @@ use std::future::Future;
 use tokio::net::TcpStream;
 use tower::util::ServiceFn;
 
-use fregate::{Application, DefaultHealth};
+use fregate::{AlwaysHealthy, Application};
 
 type _Svs = ServiceFn<dyn FnOnce(Request<Body>) -> dyn Future<Output = Response>>;
 
@@ -29,7 +29,7 @@ async fn main() {
     //     }
     // });
 
-    let app = Application::builder::<DefaultHealth>()
+    let app = Application::builder::<AlwaysHealthy>()
         .set_configuration_file("./src/resources/default_conf.toml")
         .init_metrics()
         .set_rest_routes(router)

--- a/examples/observability/src/main.rs
+++ b/examples/observability/src/main.rs
@@ -2,11 +2,11 @@ use axum::routing::get;
 use axum::Router;
 use std::net::Ipv4Addr;
 
-use fregate::{Application, DefaultHealth};
+use fregate::{AlwaysHealthy, Application};
 
 #[tokio::main]
 async fn main() {
-    let app = Application::builder::<DefaultHealth>()
+    let app = Application::builder::<AlwaysHealthy>()
         .init_metrics()
         .init_tracing()
         .set_rest_routes(Router::new().route("/", get(handler)))

--- a/examples/tonic/Cargo.toml
+++ b/examples/tonic/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "tonic"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+fregate = { path = "../.." }
+async-trait = "0.1.56"
+axum  = '0.5.1'
+tokio = { version = "1.0", features = ["full"] }
+tracing = "0.1.29"
+tonic = "0.8.0"
+prost = "0.11.0"
+
+[build-dependencies]
+tonic-build = { version = "0.8.0", features = ["prost"] }

--- a/examples/tonic/build.rs
+++ b/examples/tonic/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    tonic_build::compile_protos("proto/hello.proto").unwrap();
+    tonic_build::compile_protos("proto/echo.proto").unwrap();
+}

--- a/examples/tonic/proto/echo.proto
+++ b/examples/tonic/proto/echo.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package echo;
+
+service Echo {
+  rpc ping (EchoRequest) returns (EchoResponse);
+}
+
+message EchoRequest
+{
+  string message = 1;
+}
+
+message EchoResponse
+{
+  string message = 1;
+}

--- a/examples/tonic/proto/hello.proto
+++ b/examples/tonic/proto/hello.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package hello;
+
+service Hello {
+  rpc SayHello (HelloRequest) returns (HelloResponse) {}
+}
+
+message HelloRequest {
+  string name = 1;
+}
+
+message HelloResponse {
+  string message = 1;
+}

--- a/examples/tonic/src/main.rs
+++ b/examples/tonic/src/main.rs
@@ -1,0 +1,75 @@
+use axum::routing::get;
+use axum::Router;
+use fregate::{AlwaysHealthy, Application};
+use proto::{
+    echo_server::{Echo, EchoServer},
+    hello_server::{Hello, HelloServer},
+    EchoRequest, EchoResponse, HelloRequest, HelloResponse,
+};
+use tonic::transport::Server;
+use tonic::{Request, Response, Status};
+
+mod proto {
+    tonic::include_proto!("hello");
+    tonic::include_proto!("echo");
+}
+
+#[derive(Default)]
+struct MyHello;
+
+#[derive(Default)]
+struct MyEcho;
+
+#[tonic::async_trait]
+impl Hello for MyHello {
+    async fn say_hello(
+        &self,
+        request: Request<HelloRequest>,
+    ) -> Result<Response<HelloResponse>, Status> {
+        let reply = HelloResponse {
+            message: format!("Hello {}!", request.into_inner().name),
+        };
+
+        Ok(Response::new(reply))
+    }
+}
+
+#[tonic::async_trait]
+impl Echo for MyEcho {
+    async fn ping(&self, request: Request<EchoRequest>) -> Result<Response<EchoResponse>, Status> {
+        let reply = EchoResponse {
+            message: request.into_inner().message,
+        };
+
+        Ok(Response::new(reply))
+    }
+}
+
+async fn handler() -> &'static str {
+    "Hello, World!"
+}
+
+#[tokio::main]
+async fn main() {
+    let echo_service = EchoServer::new(MyEcho);
+    let hello_service = HelloServer::new(MyHello);
+
+    let grpc_router = Server::builder()
+        .add_service(echo_service)
+        .add_service(hello_service);
+
+    let app = Application::builder::<AlwaysHealthy>()
+        .init_tracing()
+        .set_configuration_file("./src/resources/default_conf.toml")
+        .set_rest_routes(Router::new().route("/", get(handler)))
+        .set_grpc_routes(grpc_router)
+        .build();
+
+    app.run().await.unwrap();
+}
+
+/*
+    grpcurl -plaintext -import-path ./proto -proto hello.proto -d '{"name": "Tonic"}' 0.0.0.0:5000 hello.Hello/SayHello
+    grpcurl -plaintext -import-path ./proto -proto echo.proto -d '{"message": "Echo"}' 0.0.0.0:5000 echo.Echo/ping
+    curl http://0.0.0.0:5000/v1
+*/

--- a/src/builder/health.rs
+++ b/src/builder/health.rs
@@ -2,8 +2,9 @@ use serde::Serialize;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 
+#[async_trait::async_trait]
 pub trait Health: Default + Send + Sync + 'static {
-    fn check(&self) -> HealthStatus;
+    async fn check(&self) -> HealthStatus;
 }
 
 #[derive(Serialize, Debug, Clone, Copy)]
@@ -25,10 +26,11 @@ impl Display for HealthStatus {
 }
 
 #[derive(Default)]
-pub struct DefaultHealth {}
+pub struct AlwaysHealthy {}
 
-impl Health for DefaultHealth {
-    fn check(&self) -> HealthStatus {
+#[async_trait::async_trait]
+impl Health for AlwaysHealthy {
+    async fn check(&self) -> HealthStatus {
         HealthStatus::UP
     }
 }

--- a/src/builder/router.rs
+++ b/src/builder/router.rs
@@ -16,7 +16,7 @@ static FAVICON: Bytes = Bytes::from_static(include_bytes!("../../src/resources/f
 const OPENAPI: &str = include_str!("../../src/resources/openapi.yaml");
 
 #[derive(Debug, Default)]
-pub struct RouterBuilder<H: Health> {
+pub struct RouterBuilder<H> {
     rest_routes: Option<Router>,
     health_indicator: Option<Arc<H>>,
     init_metrics: bool,

--- a/src/builder/router.rs
+++ b/src/builder/router.rs
@@ -63,7 +63,7 @@ impl<H: Health> RouterBuilder<H> {
 
     fn get_health_router(health_indicator: Arc<H>) -> Router {
         let health_handler =
-            |Extension(health): Extension<Arc<H>>| async move { Json(health.check()) };
+            |Extension(health): Extension<Arc<H>>| async move { Json(health.check().await) };
 
         Router::new()
             .route(HEALTH_PATH, get(health_handler))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,8 @@ impl Application {
     pub async fn run(mut self) -> hyper::Result<()> {
         let rest = self.rest_router;
 
-        // TODO MAKE GRPC A FEATURE ?
+        // TODO: MAKE GRPC A FEATURE ?
+        // TODO: GENERIC FOR SERVER TYPE
         if let Some(grpc_router) = self.grpc_router.take() {
             let rest = rest.map_err(BoxError::from).boxed_clone();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,23 @@
 mod builder;
 mod extensions;
 
-use axum::{routing::IntoMakeService, Router};
+use axum::{BoxError, Router as AxumRouter};
 use config::Config;
-use hyper::{server::conn::AddrIncoming, Server};
+use hyper::header::CONTENT_TYPE;
+use hyper::{Body, Request, Server};
 use std::net::SocketAddr;
 use tokio::signal;
+use tonic::transport::server::Router as TonicRouter;
+use tower::make::Shared;
+use tower::steer::Steer;
+use tower::ServiceExt;
 use tracing::info;
 
 pub use builder::*;
 
 pub struct Application {
-    server: Server<AddrIncoming, IntoMakeService<Router>>,
+    rest_router: AxumRouter,
+    grpc_router: Option<TonicRouter>,
     socket: SocketAddr,
     _config: Config,
 }
@@ -21,10 +27,38 @@ impl Application {
         ApplicationBuilder::default()
     }
 
-    pub async fn run(self) -> hyper::Result<()> {
-        info!("Start Listening on {:?}", self.socket);
-        // TODO: LISTEN ON THE BACKGROUND ?
-        self.server.with_graceful_shutdown(shutdown_signal()).await
+    pub async fn run(mut self) -> hyper::Result<()> {
+        let rest = self.rest_router;
+
+        // TODO MAKE GRPC A FEATURE ?
+        if let Some(grpc_router) = self.grpc_router.take() {
+            let rest = rest.map_err(BoxError::from).boxed_clone();
+
+            let grpc = grpc_router
+                .into_service()
+                .map_response(|r| r.map(axum::body::boxed))
+                .boxed_clone();
+
+            let http_grpc = Steer::new(vec![rest, grpc], |req: &Request<Body>, _svcs: &[_]| {
+                if req.headers().get(CONTENT_TYPE).map(|v| v.as_bytes())
+                    != Some(b"application/grpc")
+                {
+                    0
+                } else {
+                    1
+                }
+            });
+
+            let server = Server::bind(&self.socket).serve(Shared::new(http_grpc));
+
+            info!("Start Listening on {:?}", self.socket);
+            server.with_graceful_shutdown(shutdown_signal()).await
+        } else {
+            let server = Server::bind(&self.socket).serve(rest.into_make_service());
+
+            info!("Start Listening on {:?}", self.socket);
+            server.with_graceful_shutdown(shutdown_signal()).await
+        }
     }
 }
 


### PR DESCRIPTION
Add grpc support to ApplicationBuilder with use of tower::Steer:
It is easier to understand for now how Steer works, then other options, also this way we avoid adding license notions.
Still can't figure out how to make generic for hyper::Server<_, _, _> so we can save it in struct instead of saving rest_router and grpc_router and getting Server type on run..
Made Health::check() to be async.