### PR TITLE
remove Application::api_path()

### DIFF
--- a/src/utils/router.rs
+++ b/src/utils/router.rs
@@ -1,4 +1,3 @@
-use axum::Router as AxumRouter;
 use axum::{routing::get, Extension, Router};
 use bytes::Bytes;
 
@@ -10,17 +9,6 @@ const FAVICON_PATH: &str = "/favicon.ico";
 
 static FAVICON: Bytes = Bytes::from_static(include_bytes!("../../src/resources/favicon.png"));
 const OPENAPI: &str = include_str!("../../src/resources/openapi.yaml");
-
-pub(crate) fn build_application_router(
-    api_path: Option<String>,
-    rest_router: Option<AxumRouter>,
-) -> Router {
-    if let Some(api_path) = api_path {
-        Router::new().nest_optional(api_path.as_str(), rest_router)
-    } else {
-        rest_router.unwrap_or_default()
-    }
-}
 
 pub(crate) fn build_management_router<H: Health>(health_indicator: Option<H>) -> Router {
     Router::new()


### PR DESCRIPTION
Remove Application::api_path(), because of panic in Axum when trying to nest another Router with fallback it is better to remove this part and allow user to configure api path on his own, otherwise we will restrict usage of fallback which is not nice.
Also current proxy usage implementation for next case will use fallback:
let's say we want /application/check/* to be handled in our app and other requests /application/* to be redirected to another service.
We can't create two Routers and merge them since /application/check/* is in /application/* and it will panic.
The best way to handle this scenario is to have Router with /application/check/* path and fallback with /application/* so request will be redirected only if it does not match /application/check/* and match /application/* path in fallback.