### PR TITLE
remove tower::Steer

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ async fn main() {
     let config = AppConfig::default();
 
     Application::new(&config)
-        .rest_router(Router::new().route("/", get(handler)))
+        .router(Router::new().route("/", get(handler)))
         .serve()
         .await
         .unwrap();

--- a/examples/configuration/src/main.rs
+++ b/examples/configuration/src/main.rs
@@ -51,7 +51,7 @@ async fn main() {
         .unwrap();
 
     Application::new(&conf)
-        .rest_router(Router::new().route("/", get(handler)))
+        .router(Router::new().route("/", get(handler)))
         .serve()
         .await
         .unwrap();

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -12,7 +12,7 @@ async fn main() {
     let config = AppConfig::default();
 
     Application::new(&config)
-        .rest_router(Router::new().route("/", get(handler)))
+        .router(Router::new().route("/", get(handler)))
         .serve()
         .await
         .unwrap();

--- a/examples/http-proxy/src/main.rs
+++ b/examples/http-proxy/src/main.rs
@@ -42,7 +42,7 @@ async fn main() {
         .layer(http_trace_layer());
 
     Application::new(&AppConfig::default())
-        .rest_router(app)
+        .router(app)
         .serve()
         .await
         .unwrap();
@@ -61,11 +61,7 @@ async fn server() {
             post(|| async { (StatusCode::BAD_REQUEST, "Probably You Want GET Method") }),
         );
 
-    Application::new(&config)
-        .rest_router(app)
-        .serve()
-        .await
-        .unwrap();
+    Application::new(&config).router(app).serve().await.unwrap();
 }
 
 /*

--- a/examples/observability/src/main.rs
+++ b/examples/observability/src/main.rs
@@ -16,7 +16,7 @@ async fn main() {
 
     Application::new(&config)
         .health_indicator(health)
-        .rest_router(rest)
+        .router(rest)
         .serve()
         .await
         .unwrap();

--- a/examples/tonic/src/main.rs
+++ b/examples/tonic/src/main.rs
@@ -75,9 +75,10 @@ async fn main() {
         .merge(Router::from_tonic_service(hello_service))
         .layer(grpc_trace_layer());
 
+    let app_router = rest.merge(grpc);
+
     Application::new(&AppConfig::default())
-        .rest_router(rest)
-        .grpc_router(grpc)
+        .router(app_router)
         .serve()
         .await
         .unwrap();

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,12 +1,9 @@
 use crate::Optional;
 use axum::Router as AxumRouter;
-use hyper::header::CONTENT_TYPE;
-use hyper::{Body, Request, Server};
+use hyper::Server;
 use serde::de::DeserializeOwned;
 use std::net::SocketAddr;
 use tokio::signal;
-use tower::make::Shared;
-use tower::steer::Steer;
 use tracing::info;
 
 use crate::utils::*;
@@ -15,8 +12,7 @@ use crate::utils::*;
 pub struct Application<'a, H, T> {
     config: &'a AppConfig<T>,
     health_indicator: Option<H>,
-    rest_router: Option<AxumRouter>,
-    grpc_router: Option<AxumRouter>,
+    router: Option<AxumRouter>,
 }
 
 impl<'a, T: DeserializeOwned> Application<'a, AlwaysReadyAndAlive, T> {
@@ -24,8 +20,7 @@ impl<'a, T: DeserializeOwned> Application<'a, AlwaysReadyAndAlive, T> {
         Application::<'a, AlwaysReadyAndAlive, T> {
             config,
             health_indicator: Some(AlwaysReadyAndAlive {}),
-            rest_router: None,
-            grpc_router: None,
+            router: None,
         }
     }
 }
@@ -35,31 +30,19 @@ impl<'a, H: Health, T: DeserializeOwned> Application<'a, H, T> {
         Application::<'a, Hh, T> {
             config: self.config,
             health_indicator: Some(health),
-            rest_router: self.rest_router,
-            grpc_router: self.grpc_router,
+            router: self.router,
         }
     }
 
-    pub async fn serve(mut self) -> hyper::Result<()> {
-        let rest = build_management_router(self.health_indicator).merge_optional(self.rest_router);
-
+    pub async fn serve(self) -> hyper::Result<()> {
+        let app = build_management_router(self.health_indicator).merge_optional(self.router);
         let application_socket = SocketAddr::new(self.config.host, self.config.port);
 
-        // TODO: MAKE GRPC A FEATURE ?
-        if let Some(grpc) = self.grpc_router.take() {
-            run_rest_and_grpc_service(&application_socket, rest, grpc).await
-        } else {
-            run_rest_service(&application_socket, rest).await
-        }
+        run_service(&application_socket, app).await
     }
 
-    pub fn rest_router(mut self, router: AxumRouter) -> Self {
-        self.rest_router = Some(router);
-        self
-    }
-
-    pub fn grpc_router(mut self, router: AxumRouter) -> Self {
-        self.grpc_router = Some(router);
+    pub fn router(mut self, router: AxumRouter) -> Self {
+        self.router = Some(router);
         self
     }
 }
@@ -90,41 +73,9 @@ async fn shutdown_signal() {
     info!("Termination signal, starting shutdown...");
 }
 
-async fn run_rest_service(socket: &SocketAddr, rest: AxumRouter) -> hyper::Result<()> {
+async fn run_service(socket: &SocketAddr, rest: AxumRouter) -> hyper::Result<()> {
     let server = Server::bind(socket).serve(rest.into_make_service());
-    info!(target: "server", server_type = "rest", "Started: http://{socket}");
+    info!(target: "server", "Started: http://{socket}");
 
     server.with_graceful_shutdown(shutdown_signal()).await
-}
-
-async fn run_rest_and_grpc_service(
-    socket: &SocketAddr,
-    rest: AxumRouter,
-    grpc: AxumRouter,
-) -> hyper::Result<()> {
-    let rest_grpc = Steer::new(
-        [rest, grpc],
-        |req: &Request<Body>, _svcs: &[_]| {
-            if is_grpc_request(req) {
-                1
-            } else {
-                0
-            }
-        },
-    );
-
-    let server = Server::bind(socket).serve(Shared::new(rest_grpc));
-    info!(target: "server", server_type = "rest + grpc", "Started: http://{socket}");
-
-    server.with_graceful_shutdown(shutdown_signal()).await
-}
-
-#[inline(always)]
-fn is_grpc_request(req: &Request<Body>) -> bool {
-    if let Some(content_type) = req.headers().get(CONTENT_TYPE) {
-        // some gRPC clients uses `application/grpc+<additional type>` header
-        content_type.as_bytes().starts_with(b"application/grpc")
-    } else {
-        false
-    }
 }


### PR DESCRIPTION
We have Router::from_tonic_service() which takes Tonic service and returns axum::Router it means we might merge it with any axum::Router, so we do not need to differentiate in Application between rest and grpc Routers, we simply might force to merge resulted Routers into one and take it as argument. 
This way we will rely only on path matching mechanism from axum::Router skipping the part of checking ContentType.
from examples/tonic
```rust
#[tokio::main]
async fn main() {
    init_tracing();

    let echo_service = EchoServer::new(MyEcho);
    let hello_service = HelloServer::new(MyHello);

    let rest = Router::new()
        .route("/", get(|| async { "Hello, World!" }))
        .layer(http_trace_layer());

    // Echo service will always deny request
    let grpc = Router::from_tonic_service(echo_service)
        .layer(from_fn(deny_middleware))
        .merge(Router::from_tonic_service(hello_service))
        .layer(grpc_trace_layer());

    let app_router = rest.merge(grpc);

    Application::new(&AppConfig::default())
        .router(app_router)
        .serve()
        .await
        .unwrap();
}