### PR TITLE
Log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,16 @@ mime = "0.3.16"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 prost = "0.11.0"
+time = "0.3.14"
 tokio = { version = "1.0", features = ["full"] }
 tonic = "0.8.0"
 tower = { version = "0.4", features = ["full"] }
 tower-http = { version = "0.3", features = ["full"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3.11", features = ["env-filter", "fmt", "json", "time", "tracing-log"] }
+tracing-subscriber = { version = "0.3.11", features = ["env-filter", "fmt", "std", "json", "time", "tracing-log", "registry"] }
+tracing-opentelemetry = "0.17.4"
+opentelemetry = { version = "0.17.0", features = ["rt-async-std"]}
+opentelemetry-otlp = { version = "0.10.0", features = ["grpc-sys"] }
+opentelemetry-http = "0.6.0"
+opentelemetry-zipkin = "0.15.0"
+

--- a/README.md
+++ b/README.md
@@ -8,20 +8,16 @@ This project in progress and might change a lot from version to version.
 
 ## Usage example
 ```rust
+async fn handler() -> &'static str {
+    "Hello, World!"
+}
+
 #[tokio::main]
 async fn main() {
-    init_tracing();
-
-    let config = AppConfig::default();
-
-    Application::new(&config)
+    Application::new(&AppConfig::default())
         .router(Router::new().route("/", get(handler)))
         .serve()
         .await
         .unwrap();
-}
-
-async fn handler() -> &'static str {
-    "Hello, World!"
 }
 ```

--- a/examples/configuration/src/main.rs
+++ b/examples/configuration/src/main.rs
@@ -1,7 +1,5 @@
-use fregate::axum::routing::get;
-use fregate::axum::Router;
-use fregate::config::FileFormat;
-use fregate::{init_tracing, AppConfig, Application, Empty};
+use fregate::axum::{routing::get, Router};
+use fregate::{AppConfig, Application};
 use serde::Deserialize;
 
 async fn handler() -> &'static str {
@@ -16,41 +14,42 @@ struct Custom {
 
 #[tokio::main]
 async fn main() {
-    init_tracing();
-
     std::env::set_var("TEST_PORT", "3333");
     std::env::set_var("TEST_NUMBER", "1010");
     std::env::set_var("TEST_LOG_LEVEL", "debug");
+    std::env::set_var("TEST_TRACE_LEVEL", "debug");
     std::env::set_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://0.0.0.0:4317");
     std::env::set_var("OTEL_SERVICE_NAME", "CONFIGURATION");
 
-    // Only if default settings needed
-    let _conf = AppConfig::default();
+    /*
+        // Only if default settings needed
+        let _conf = AppConfig::default();
 
-    // Read default, overwrite with envs, overwrite with file
-    let _conf = AppConfig::builder()
-        .add_default()
-        .add_env_prefixed("TEST")
-        .add_file("./examples/configuration/app.yaml")
-        .add_str(include_str!("../app.yaml"), FileFormat::Yaml)
-        .build()
-        .unwrap();
+        // Read default, overwrite with envs, overwrite with file
+        let _conf = AppConfig::<Empty>::builder()
+            .add_default()
+            .add_env_prefixed("TEST")
+            .add_file("./examples/configuration/app.yaml")
+            .add_str(include_str!("../app.yaml"), FileFormat::Yaml)
+            .build()
+            .unwrap();
+
+        // Try to deserialize with private field, here you can add any number of sources
+        let conf: AppConfig<Custom> = AppConfig::builder()
+            .add_default()
+            .add_env_prefixed("TEST")
+            .init_tracing()
+            .build()
+            .unwrap();
+
+        // if do not need private field use Empty struct from crate
+        let _conf: AppConfig<Empty> =
+            AppConfig::default_with("./examples/configuration/app.yaml", "TEST").unwrap();
+    */
 
     // Or most popular use cases:
-    // set type for private field
-    let _conf: AppConfig<Custom> =
+    let conf: AppConfig<Custom> =
         AppConfig::default_with("./examples/configuration/app.yaml", "TEST").unwrap();
-
-    // if do not need private field use Empty struct from crate
-    let _conf: AppConfig<Empty> =
-        AppConfig::default_with("./examples/configuration/app.yaml", "TEST").unwrap();
-
-    // Try to deserialize with private field, here you can add any number of sources
-    let conf: AppConfig<Custom> = AppConfig::builder_with_private()
-        .add_default()
-        .add_env_prefixed("TEST")
-        .build()
-        .unwrap();
 
     Application::new(&conf)
         .router(Router::new().route("/", get(handler)))

--- a/examples/configuration/src/main.rs
+++ b/examples/configuration/src/main.rs
@@ -25,10 +25,11 @@ async fn main() {
         // Only if default settings needed
         let _conf = AppConfig::default();
 
-        // Read default, overwrite with envs, overwrite with file
+        // Read default, overwrite with envs, overwrite with file, init tracing (initialised by default)
         let _conf = AppConfig::<Empty>::builder()
             .add_default()
             .add_env_prefixed("TEST")
+            .init_tracing()
             .add_file("./examples/configuration/app.yaml")
             .add_str(include_str!("../app.yaml"), FileFormat::Yaml)
             .build()

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -1,5 +1,5 @@
 use fregate::axum::routing::get;
-use fregate::{axum::Router, init_tracing, AppConfig, Application};
+use fregate::{axum::Router, AppConfig, Application};
 
 async fn handler() -> &'static str {
     "Hello, World!"
@@ -7,11 +7,7 @@ async fn handler() -> &'static str {
 
 #[tokio::main]
 async fn main() {
-    init_tracing();
-
-    let config = AppConfig::default();
-
-    Application::new(&config)
+    Application::new(&AppConfig::default())
         .router(Router::new().route("/", get(handler)))
         .serve()
         .await

--- a/examples/log-level-change/Cargo.toml
+++ b/examples/log-level-change/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "examples-http-proxy"
+name = "examples-log-level-change"
 version = "0.1.0"
 edition = "2021"
 
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 fregate = { path = "../.." }
 tokio = { version = "1.0", features = ["full"] }
+tracing-subscriber = "0.3.15"

--- a/examples/log-level-change/src/main.rs
+++ b/examples/log-level-change/src/main.rs
@@ -1,0 +1,41 @@
+use fregate::{
+    axum::{routing::get, Router},
+    http_trace_layer, AppConfig, Application,
+};
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+use tracing_subscriber::EnvFilter;
+
+// Change log level after 10 seconds.
+// Default log level is INFO
+// Will be changed to TRACE
+#[tokio::main]
+async fn main() {
+    let conf = Arc::new(AppConfig::default());
+
+    let config = conf.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        let config = config;
+        let log_filter_reloader = config.get_log_filter_reload().unwrap();
+
+        log_filter_reloader
+            .modify(|filter| *filter.filter_mut() = EnvFilter::from_str("trace").unwrap())
+            .unwrap()
+    });
+
+    let rest = Router::new()
+        .route("/", get(handler))
+        .layer(http_trace_layer());
+
+    Application::new(&conf).router(rest).serve().await.unwrap();
+}
+
+async fn handler() -> &'static str {
+    "Hello, World!"
+}
+
+/*
+    curl http://0.0.0.0:8000
+*/

--- a/examples/observability/src/main.rs
+++ b/examples/observability/src/main.rs
@@ -1,21 +1,15 @@
 use fregate::{
     axum::{routing::get, Router},
-    http_trace_layer, init_tracing, AlwaysReadyAndAlive, AppConfig, Application,
+    http_trace_layer, AppConfig, Application,
 };
 
 #[tokio::main]
 async fn main() {
-    init_tracing();
-
-    let config = AppConfig::default();
-    let health = AlwaysReadyAndAlive::default();
-
     let rest = Router::new()
         .route("/", get(handler))
         .layer(http_trace_layer());
 
-    Application::new(&config)
-        .health_indicator(health)
+    Application::new(&AppConfig::default())
         .router(rest)
         .serve()
         .await

--- a/examples/tonic/src/main.rs
+++ b/examples/tonic/src/main.rs
@@ -58,7 +58,7 @@ async fn deny_middleware<B>(_req: Request<B>, _next: Next<B>) -> impl IntoRespon
 
 #[tokio::main]
 async fn main() {
-    init_tracing();
+    let config = &AppConfig::default();
 
     let echo_service = EchoServer::new(MyEcho);
     let hello_service = HelloServer::new(MyHello);
@@ -75,7 +75,7 @@ async fn main() {
 
     let app_router = rest.merge(grpc);
 
-    Application::new(&AppConfig::default())
+    Application::new(config)
         .router(app_router)
         .serve()
         .await

--- a/examples/tonic/src/main.rs
+++ b/examples/tonic/src/main.rs
@@ -6,9 +6,7 @@ use fregate::axum::{
 };
 use fregate::hyper::Request;
 use fregate::tonic::{Request as TonicRequest, Response as TonicResponse, Status};
-use fregate::{
-    grpc_trace_layer, http_trace_layer, init_tracing, AppConfig, Application, Tonicable,
-};
+use fregate::{grpc_trace_layer, http_trace_layer, AppConfig, Application, Tonicable};
 use proto::{
     echo_server::{Echo, EchoServer},
     hello_server::{Hello, HelloServer},

--- a/src/resources/default_conf.toml
+++ b/src/resources/default_conf.toml
@@ -4,6 +4,9 @@ port = 8000
 [log]
 level = "info"
 
+[trace]
+level = "info"
+
 [service]
 name = "Rust"
 

--- a/src/utils/configuration.rs
+++ b/src/utils/configuration.rs
@@ -1,4 +1,4 @@
-use crate::{init_tracing, ConsoleLayerReload, DeserializeExt, OTLPLayerReload, CONFIG_IS_READ};
+use crate::{init_tracing, DeserializeExt, LogLayerReload, TraceLayerReload, CONFIG_IS_READ};
 use config::{builder::DefaultState, ConfigBuilder, ConfigError, Environment, File, FileFormat};
 use serde::{
     de::{DeserializeOwned, Error},
@@ -34,8 +34,8 @@ pub struct LoggerConfig {
     pub trace_level: String,
     pub service_name: String,
     pub traces_endpoint: Option<String>,
-    pub log_filter_reloader: Option<ConsoleLayerReload>,
-    pub traces_filter_reloader: Option<OTLPLayerReload>,
+    pub log_filter_reloader: Option<LogLayerReload>,
+    pub traces_filter_reloader: Option<TraceLayerReload>,
 }
 
 impl Debug for LoggerConfig {
@@ -130,6 +130,10 @@ impl<T: DeserializeOwned + Debug> AppConfig<T> {
             .add_file(file_path)
             .add_env_prefixed(env_prefix)
             .build()
+    }
+
+    pub fn get_log_filter_reload(&self) -> Option<&LogLayerReload> {
+        self.logger.log_filter_reloader.as_ref()
     }
 }
 

--- a/src/utils/configuration.rs
+++ b/src/utils/configuration.rs
@@ -121,6 +121,12 @@ impl Default for AppConfig<Empty> {
     }
 }
 
+impl<T> AppConfig<T> {
+    pub fn get_log_filter_reload(&self) -> Option<&LogLayerReload> {
+        self.logger.log_filter_reloader.as_ref()
+    }
+}
+
 impl<T: DeserializeOwned + Debug> AppConfig<T> {
     pub fn builder() -> AppConfigBuilder<T> {
         AppConfigBuilder::new()
@@ -133,10 +139,6 @@ impl<T: DeserializeOwned + Debug> AppConfig<T> {
             .add_file(file_path)
             .add_env_prefixed(env_prefix)
             .build()
-    }
-
-    pub fn get_log_filter_reload(&self) -> Option<&LogLayerReload> {
-        self.logger.log_filter_reloader.as_ref()
     }
 }
 

--- a/src/utils/configuration.rs
+++ b/src/utils/configuration.rs
@@ -1,15 +1,16 @@
-use crate::{DeserializeAndLog, DeserializeExt, Result};
-use config::{builder::DefaultState, ConfigBuilder, Environment, File, FileFormat};
+use crate::{init_tracing, ConsoleLayerReload, DeserializeExt, OTLPLayerReload, CONFIG_IS_READ};
+use config::{builder::DefaultState, ConfigBuilder, ConfigError, Environment, File, FileFormat};
 use serde::{
     de::{DeserializeOwned, Error},
     Deserialize, Deserializer,
 };
 use serde_json::{from_value, Value};
-use std::{fmt::Debug, marker::PhantomData, net::IpAddr};
+use std::{fmt::Debug, fmt::Formatter, marker::PhantomData, net::IpAddr, sync::atomic::Ordering};
 
 const HOST_PTR: &str = "/host";
 const PORT_PTR: &str = "/port";
 const LOG_LEVEL_PTR: &str = "/log/level";
+const TRACE_LEVEL_PTR: &str = "/trace/level";
 const SERVICE_NAME_PTR: &str = "/service/name";
 const TRACES_ENDPOINT_PTR: &str = "/exporter/otlp/traces/endpoint";
 const DEFAULT_CONFIG: &str = include_str!("../resources/default_conf.toml");
@@ -18,29 +19,50 @@ const DEFAULT_SEPARATOR: &str = "_";
 #[derive(Debug, Deserialize)]
 pub struct Empty {}
 
+/// Make sure you build only one AppConfig for server, trying to build more then 1 will return Error
 #[derive(Debug)]
 pub struct AppConfig<T> {
     pub host: IpAddr,
     pub port: u16,
     pub logger: LoggerConfig,
+    pub init_tracing: bool,
     pub private: T,
 }
 
-#[derive(Debug)]
 pub struct LoggerConfig {
     pub log_level: String,
+    pub trace_level: String,
     pub service_name: String,
     pub traces_endpoint: Option<String>,
+    pub log_filter_reloader: Option<ConsoleLayerReload>,
+    pub traces_filter_reloader: Option<OTLPLayerReload>,
+}
+
+impl Debug for LoggerConfig {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LoggerConfig")
+            .field("log_level", &self.log_level)
+            .field("trace_level", &self.trace_level)
+            .field("service_name", &self.service_name)
+            .field("traces_endpoint", &self.traces_endpoint)
+            .field("log_filter_reloader", &self.log_filter_reloader.is_some())
+            .field(
+                "traces_filter_reloader",
+                &self.traces_filter_reloader.is_some(),
+            )
+            .finish()
+    }
 }
 
 impl<'de> Deserialize<'de> for LoggerConfig {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
         let mut config = Value::deserialize(deserializer)?;
 
         let log_level = config.pointer_and_deserialize(LOG_LEVEL_PTR)?;
+        let trace_level = config.pointer_and_deserialize(TRACE_LEVEL_PTR)?;
         let service_name = config.pointer_and_deserialize(SERVICE_NAME_PTR)?;
         let traces_endpoint_ptr = config.pointer_mut(TRACES_ENDPOINT_PTR);
 
@@ -52,8 +74,11 @@ impl<'de> Deserialize<'de> for LoggerConfig {
 
         Ok(LoggerConfig {
             log_level,
+            trace_level,
             service_name,
             traces_endpoint,
+            log_filter_reloader: None,
+            traces_filter_reloader: None,
         })
     }
 }
@@ -62,7 +87,7 @@ impl<'de, T> Deserialize<'de> for AppConfig<T>
 where
     T: Debug + DeserializeOwned,
 {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -76,6 +101,7 @@ where
         Ok(AppConfig::<T> {
             host,
             port,
+            init_tracing: false,
             logger,
             private,
         })
@@ -86,34 +112,31 @@ impl Default for AppConfig<Empty> {
     fn default() -> Self {
         AppConfig::builder()
             .add_default()
+            .init_tracing()
             .build()
             .expect("Default config never fails")
     }
 }
 
 impl<T: DeserializeOwned + Debug> AppConfig<T> {
-    pub fn builder_with_private() -> AppConfigBuilder<T> {
+    pub fn builder() -> AppConfigBuilder<T> {
         AppConfigBuilder::new()
     }
 
-    pub fn default_with(file_path: &str, env_prefix: &str) -> Result<Self> {
-        AppConfig::builder_with_private()
+    pub fn default_with(file_path: &str, env_prefix: &str) -> Result<Self, ConfigError> {
+        AppConfig::builder()
             .add_default()
+            .init_tracing()
             .add_file(file_path)
             .add_env_prefixed(env_prefix)
             .build()
     }
 }
 
-impl AppConfig<Empty> {
-    pub fn builder() -> AppConfigBuilder<Empty> {
-        AppConfigBuilder::new()
-    }
-}
-
 #[derive(Debug, Default)]
 pub struct AppConfigBuilder<T> {
     builder: ConfigBuilder<DefaultState>,
+    init_tracing: bool,
     phantom: PhantomData<T>,
 }
 
@@ -121,14 +144,29 @@ impl<T: DeserializeOwned + Debug> AppConfigBuilder<T> {
     pub fn new() -> Self {
         Self {
             builder: ConfigBuilder::default(),
+            init_tracing: false,
             phantom: PhantomData,
         }
     }
 
-    pub fn build(self) -> Result<AppConfig<T>> {
-        self.builder
-            .build()?
-            .try_deserialize_and_log::<AppConfig<T>>()
+    pub fn build(self) -> Result<AppConfig<T>, ConfigError> {
+        if CONFIG_IS_READ.swap(true, Ordering::SeqCst) {
+            panic!("Only one config is allowed to read")
+        }
+
+        let mut config = self.builder.build()?.try_deserialize::<AppConfig<T>>()?;
+        config.init_tracing = self.init_tracing;
+
+        if config.init_tracing {
+            init_tracing(&mut config);
+        }
+
+        Ok(config)
+    }
+
+    pub fn init_tracing(mut self) -> Self {
+        self.init_tracing = true;
+        self
     }
 
     pub fn add_default(mut self) -> Self {

--- a/src/utils/configuration.rs
+++ b/src/utils/configuration.rs
@@ -1,10 +1,11 @@
-use crate::{init_tracing, DeserializeExt, LogLayerReload, TraceLayerReload, CONFIG_IS_READ};
+use crate::{init_tracing, DeserializeExt, LogLayerReload, TraceLayerReload};
 use config::{builder::DefaultState, ConfigBuilder, ConfigError, Environment, File, FileFormat};
 use serde::{
     de::{DeserializeOwned, Error},
     Deserialize, Deserializer,
 };
 use serde_json::{from_value, Value};
+use std::sync::atomic::AtomicBool;
 use std::{fmt::Debug, fmt::Formatter, marker::PhantomData, net::IpAddr, sync::atomic::Ordering};
 
 const HOST_PTR: &str = "/host";
@@ -16,10 +17,12 @@ const TRACES_ENDPOINT_PTR: &str = "/exporter/otlp/traces/endpoint";
 const DEFAULT_CONFIG: &str = include_str!("../resources/default_conf.toml");
 const DEFAULT_SEPARATOR: &str = "_";
 
+static CONFIG_IS_READ: AtomicBool = AtomicBool::new(false);
+
 #[derive(Debug, Deserialize)]
 pub struct Empty {}
 
-/// Make sure you build only one AppConfig for server, trying to build more then 1 will return Error
+/// Make sure you build only one AppConfig for server, trying to build more then 1 will cause panic
 #[derive(Debug)]
 pub struct AppConfig<T> {
     pub host: IpAddr,

--- a/src/utils/configuration.rs
+++ b/src/utils/configuration.rs
@@ -1,5 +1,6 @@
 use crate::{init_tracing, DeserializeExt, LogLayerReload, TraceLayerReload};
 use config::{builder::DefaultState, ConfigBuilder, ConfigError, Environment, File, FileFormat};
+use opentelemetry::global::shutdown_tracer_provider;
 use serde::{
     de::{DeserializeOwned, Error},
     Deserialize, Deserializer,
@@ -202,5 +203,11 @@ impl<T: DeserializeOwned + Debug> AppConfigBuilder<T> {
                 .separator(DEFAULT_SEPARATOR),
         );
         self
+    }
+}
+
+impl<T> Drop for AppConfig<T> {
+    fn drop(&mut self) {
+        shutdown_tracer_provider();
     }
 }

--- a/src/utils/logging.rs
+++ b/src/utils/logging.rs
@@ -24,8 +24,8 @@ use tracing_subscriber::{
 
 pub(crate) static CONFIG_IS_READ: AtomicBool = AtomicBool::new(false);
 
-pub type ConsoleLayerReload = Handle<Filtered<DefaultLayer, EnvFilter, Registry>, Registry>;
-pub type OTLPLayerReload = Handle<
+pub type LogLayerReload = Handle<Filtered<DefaultLayer, EnvFilter, Registry>, Registry>;
+pub type TraceLayerReload = Handle<
     Filtered<OpenTelemetryLayer<DefaultLayered, Tracer>, EnvFilter, DefaultLayered>,
     DefaultLayered,
 >;
@@ -76,7 +76,7 @@ pub(crate) fn init_tracing<T>(config: &mut AppConfig<T>) {
     let log_level = EnvFilter::from_str(settings.log_level.as_str()).unwrap_or_default();
     settings.log_level = log_level.to_string();
 
-    let console_layer = layer()
+    let log_filter = layer()
         .json()
         .with_timer(UtcTime::rfc_3339())
         .flatten_event(true)
@@ -85,7 +85,7 @@ pub(crate) fn init_tracing<T>(config: &mut AppConfig<T>) {
         .with_span_events(FmtSpan::NONE)
         .with_filter(log_level);
 
-    let (log_filter, log_filter_reloader) = reload::Layer::new(console_layer);
+    let (log_filter, log_filter_reloader) = reload::Layer::new(log_filter);
     settings.log_filter_reloader.replace(log_filter_reloader);
 
     registry().with(log_filter).with(traces_filter).init();

--- a/src/utils/logging.rs
+++ b/src/utils/logging.rs
@@ -29,7 +29,7 @@ pub type LogLayer = reload::Layer<LogFiltered, Registry>;
 pub type LogLayerReload = Handle<LogFiltered, Registry>;
 
 pub type TraceFiltered = Filtered<OTLayer<DefaultLayered, Tracer>, EnvFilter, DefaultLayered>;
-pub type TraceLayer = reload::Layer<TraceFiltered, DefaultLayered>;
+pub type TraceLayer = TraceFiltered;
 pub type TraceLayerReload = Handle<TraceFiltered, DefaultLayered>;
 
 fn get_log_filter<T>(config: &mut AppConfig<T>) -> LogLayer {
@@ -83,12 +83,13 @@ fn get_trace_filter<T>(config: &mut AppConfig<T>) -> Option<TraceLayer> {
             .with_tracer(tracer)
             .with_filter(trace_level);
 
-        let (traces_filter, traces_filter_reloader) = reload::Layer::new(opentelemetry_layer);
-        settings
-            .traces_filter_reloader
-            .replace(traces_filter_reloader);
+        // TODO: bug ? trace_id is not generated when used with reload Layer
+        // let (traces_filter, traces_filter_reloader) = reload::Layer::new(opentelemetry_layer);
+        // settings
+        //     .traces_filter_reloader
+        //     .replace(traces_filter_reloader);
 
-        Some(traces_filter)
+        Some(opentelemetry_layer)
     } else {
         None
     }


### PR DESCRIPTION
The idea is to put init_tracing() call into AppConfig and put  log_filter_reload and trace_filter_reload  into AppConfig so that log filter and trace filter might be changed in runtime.
Tracing subscriber is global so log filter and trace filter are, but potentially we might want to read multiple AppConfigs, this will be prohibited and app will panic, controlled by static AtomicBool.
We might have static mut variables for log and trace filters but we initialise them through AppConfig and if we have multiple AppConfigs in app we need to choose which one will initialise them, this way we bring multiple problems like (forgot to initialise, wrong AppConfig, AppConfig which should initialise traces and logs is read after some internal logs should be printed)
With current implementation only 1 AppConfig is allowed to read. If more variables are needed to be read we might put it into private field of AppConfig<T>.
Examples:
Hello World example:
This will have logs initialised but not traces exports, since OTEL_EXPORTER_OTLP_TRACES_ENDPOINT is not set and there is nowhere to export them (Will change logic a little here, so trace_id will be propagated even if there is nowhere to export traces, we will have trace_ids in logs)
```rust
async fn handler() -> &'static str {
    "Hello, World!"
}

#[tokio::main]
async fn main() {
    Application::new(&AppConfig::default())
        .router(Router::new().route("/", get(handler)))
        .serve()
        .await
        .unwrap();
}
```

If need AppConfig without logs and traces then call AppConfig builder
```rust
    let conf = AppConfig::<Empty>::builder()
        .add_default()
//     .init_tracing() call to init tracing (called by default)
        .add_env_prefixed("TEST")
        .build()
        .unwrap();
```        
But reading 2 AppConfigs even if 1 or 2 does not init tracing is prohibited.
This Will Panic
```rust  
    let conf = AppConfig::default();
    let conf = AppConfig::<Empty>::builder()
        .add_default()
        .add_env_prefixed("TEST")
        .build()
        .unwrap();
```

Changing log level in 10 seconds after start
```rust
#[tokio::main]
async fn main() {
    let config = Arc::new(AppConfig::default());
    let conf = config.clone();

    tokio::spawn(async move {
        tokio::time::sleep(Duration::from_secs(10)).await;

        let filter_reload = conf.get_log_filter_reload().unwrap();
        filter_reload
            .modify(|f| *f.filter_mut() = EnvFilter::from_str("trace").unwrap_or_default())
            .unwrap();
    });

    let rest = Router::new()
        .route("/", get(handler))
        .layer(http_trace_layer());

    Application::new(&config)
        .router(rest)
        .serve()
        .await
        .unwrap();
}

async fn handler() -> &'static str {
    "Hello, World!"
}
```
This is draft PR so please share your opinion and If we find this idea appealing I will refactor code prior to merging.