### PR TITLE
Add flags for building with openssl instead of boringssl.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ categories = ["web-programming"]
 keywords = ["http", "grpc", "service"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["openssl"]
+openssl = ["opentelemetry-otlp/openssl"]
+openssl-vendored = ["opentelemetry-otlp/openssl-vendored"]
+
 [workspace]
 members = ["examples/*"]
 
@@ -36,7 +41,7 @@ tower-http = { version = "0.3", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter", "fmt", "std", "json", "time", "tracing-log", "registry"] }
 tracing-opentelemetry = "0.17.4"
-opentelemetry = { version = "0.17.0", features = ["rt-tokio"]}
-opentelemetry-otlp = { version = "0.10.0", features = ["grpc-sys"] }
-opentelemetry-http = "0.6.0"
-opentelemetry-zipkin = "0.15.0"
+opentelemetry = { version = "0.18.0", features = ["rt-tokio"]}
+opentelemetry-otlp = { version = "0.11.0", features = ["grpc-sys"] }
+opentelemetry-http = "0.7.0"
+opentelemetry-zipkin = "0.16.0"


### PR DESCRIPTION
Add ability to use system `openssl` or `openssl-vendored` instead of `boringssl`.

Draft because of: https://github.com/open-telemetry/opentelemetry-rust/issues/877
`opentelemetry-otlp` uses `grpcio` 0.9 which still take `boringssl-src` as dependency.