### PR TITLE
Bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ async fn handler() -> &'static str {
 
 #[tokio::main]
 async fn main() {
-    Application::new(&AppConfig::default())
+    let config = bootstrap::<Empty, _>([]);
+
+    Application::new(&config)
         .router(Router::new().route("/", get(handler)))
         .serve()
         .await

--- a/examples/configuration/src/main.rs
+++ b/examples/configuration/src/main.rs
@@ -23,10 +23,10 @@ async fn main() {
     std::env::set_var("OTEL_SERVICE_NAME", "CONFIGURATION");
 
     // This will initialise tracing from environment variables read to AppConfig.
-    let _conf: AppConfig<Empty> = bootstrap(
-        [ConfigSource::File("./examples/configuration/app.yaml")],
-        None,
-    );
+    let _conf: AppConfig<Empty> = bootstrap([
+        ConfigSource::File("./examples/configuration/app.yaml"),
+        ConfigSource::EnvPrefix("TEST"),
+    ]);
 
     let _conf = AppConfig::default();
 

--- a/examples/configuration/src/main.rs
+++ b/examples/configuration/src/main.rs
@@ -1,5 +1,6 @@
 use fregate::axum::{routing::get, Router};
-use fregate::{AppConfig, Application};
+use fregate::config::FileFormat;
+use fregate::{bootstrap, AppConfig, Application, ConfigSource, Empty};
 use serde::Deserialize;
 
 async fn handler() -> &'static str {
@@ -21,38 +22,26 @@ async fn main() {
     std::env::set_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://0.0.0.0:4317");
     std::env::set_var("OTEL_SERVICE_NAME", "CONFIGURATION");
 
-    /*
-        // Only if default settings needed
-        let _conf = AppConfig::default();
+    // This will initialise tracing from environment variables read to AppConfig.
+    let _conf: AppConfig<Empty> = bootstrap(
+        [ConfigSource::File("./examples/configuration/app.yaml")],
+        None,
+    );
 
-        // Read default, overwrite with envs, overwrite with file, init tracing (initialised by default)
-        let _conf = AppConfig::<Empty>::builder()
-            .add_default()
-            .add_env_prefixed("TEST")
-            .init_tracing()
-            .add_file("./examples/configuration/app.yaml")
-            .add_str(include_str!("../app.yaml"), FileFormat::Yaml)
-            .build()
-            .unwrap();
+    let _conf = AppConfig::default();
 
-        // Try to deserialize with private field, here you can add any number of sources
-        let conf: AppConfig<Custom> = AppConfig::builder()
-            .add_default()
-            .add_env_prefixed("TEST")
-            .init_tracing()
-            .build()
-            .unwrap();
+    let _conf = AppConfig::<Empty>::builder()
+        .add_default()
+        .add_env_prefixed("TEST")
+        .add_file("./examples/configuration/app.yaml")
+        .add_str(include_str!("../app.yaml"), FileFormat::Yaml)
+        .build()
+        .unwrap();
 
-        // if do not need private field use Empty struct from crate
-        let _conf: AppConfig<Empty> =
-            AppConfig::default_with("./examples/configuration/app.yaml", "TEST").unwrap();
-    */
-
-    // Or most popular use cases:
-    let conf: AppConfig<Custom> =
+    let _conf: AppConfig<Custom> =
         AppConfig::default_with("./examples/configuration/app.yaml", "TEST").unwrap();
 
-    Application::new(&conf)
+    Application::new(&AppConfig::default())
         .router(Router::new().route("/", get(handler)))
         .serve()
         .await

--- a/examples/grafana/src/client.rs
+++ b/examples/grafana/src/client.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     std::env::set_var("OTEL_SERVICE_NAME", "CLIENT");
     std::env::set_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://0.0.0.0:4317");
 
-    let _config = bootstrap::<Empty, _>([], None);
+    let _config = bootstrap::<Empty, _>([]);
 
     let channel = tonic::transport::Endpoint::from_static("http://0.0.0.0:8000")
         .connect()

--- a/examples/grafana/src/client.rs
+++ b/examples/grafana/src/client.rs
@@ -2,7 +2,8 @@ mod proto {
     tonic::include_proto!("hello");
 }
 
-use fregate::AppConfig;
+use fregate::{bootstrap, Empty};
+use opentelemetry::global::shutdown_tracer_provider;
 use opentelemetry::propagation::Injector;
 use proto::{hello_client::HelloClient, HelloRequest, HelloResponse};
 use tonic::transport::Channel;
@@ -55,7 +56,8 @@ async fn send_hello(
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     std::env::set_var("OTEL_SERVICE_NAME", "CLIENT");
     std::env::set_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://0.0.0.0:4317");
-    let _config = AppConfig::default();
+
+    let _config = bootstrap::<Empty, _>([], None);
 
     let channel = tonic::transport::Endpoint::from_static("http://0.0.0.0:8000")
         .connect()
@@ -69,5 +71,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     send_hello(&mut client, request).await?;
 
+    shutdown_tracer_provider();
     Ok(())
 }

--- a/examples/grafana/src/server.rs
+++ b/examples/grafana/src/server.rs
@@ -33,7 +33,7 @@ async fn main() {
     std::env::set_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://0.0.0.0:4317");
     std::env::set_var("OTEL_PORT", "3000");
 
-    let config = bootstrap::<Empty, _>([], None);
+    let config = bootstrap::<Empty, _>([]);
 
     let hello_service = HelloServer::new(MyHello);
     let grpc = Router::from_tonic_service(hello_service).layer(grpc_trace_layer());

--- a/examples/health/src/main.rs
+++ b/examples/health/src/main.rs
@@ -26,7 +26,7 @@ impl Health for CustomHealth {
 
 #[tokio::main]
 async fn main() {
-    let config = bootstrap::<Empty, _>([], None);
+    let config = bootstrap::<Empty, _>([]);
 
     Application::new(&config)
         .health_indicator(CustomHealth::default())

--- a/examples/health/src/main.rs
+++ b/examples/health/src/main.rs
@@ -1,4 +1,4 @@
-use fregate::{axum, AppConfig, Application, ApplicationStatus, Health};
+use fregate::{axum, bootstrap, Application, ApplicationStatus, Empty, Health};
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 
@@ -26,7 +26,9 @@ impl Health for CustomHealth {
 
 #[tokio::main]
 async fn main() {
-    Application::new(&AppConfig::default())
+    let config = bootstrap::<Empty, _>([], None);
+
+    Application::new(&config)
         .health_indicator(CustomHealth::default())
         .serve()
         .await

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -7,7 +7,7 @@ async fn handler() -> &'static str {
 
 #[tokio::main]
 async fn main() {
-    let config = bootstrap::<Empty, _>([], None);
+    let config = bootstrap::<Empty, _>([]);
 
     Application::new(&config)
         .router(Router::new().route("/", get(handler)))

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -1,5 +1,5 @@
 use fregate::axum::routing::get;
-use fregate::{axum::Router, AppConfig, Application};
+use fregate::{axum::Router, bootstrap, Application, Empty};
 
 async fn handler() -> &'static str {
     "Hello, World!"
@@ -7,7 +7,9 @@ async fn handler() -> &'static str {
 
 #[tokio::main]
 async fn main() {
-    Application::new(&AppConfig::default())
+    let config = bootstrap::<Empty, _>([], None);
+
+    Application::new(&config)
         .router(Router::new().route("/", get(handler)))
         .serve()
         .await

--- a/examples/http-proxy/src/main.rs
+++ b/examples/http-proxy/src/main.rs
@@ -3,13 +3,15 @@ use fregate::axum::{
     Router, Server,
 };
 use fregate::hyper::{Client, StatusCode};
-use fregate::{http_trace_layer, AppConfig, Application, ProxyLayer};
+use fregate::{bootstrap, http_trace_layer, Application, Empty, ProxyLayer};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 #[tokio::main]
 async fn main() {
+    let config = bootstrap::<Empty, _>([], None);
+
     // Start server where to proxy requests
     tokio::spawn(server());
 
@@ -37,11 +39,7 @@ async fn main() {
         .nest("/app", hello.merge(world).merge(might_be_proxied))
         .layer(http_trace_layer());
 
-    Application::new(&AppConfig::default())
-        .router(app)
-        .serve()
-        .await
-        .unwrap();
+    Application::new(&config).router(app).serve().await.unwrap();
 }
 
 async fn server() {

--- a/examples/http-proxy/src/main.rs
+++ b/examples/http-proxy/src/main.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() {
-    let config = bootstrap::<Empty, _>([], None);
+    let config = bootstrap::<Empty, _>([]);
 
     // Start server where to proxy requests
     tokio::spawn(server());

--- a/examples/log-level-change/src/main.rs
+++ b/examples/log-level-change/src/main.rs
@@ -11,7 +11,7 @@ use tracing_subscriber::EnvFilter;
 // Will be changed to TRACE
 #[tokio::main]
 async fn main() {
-    let conf = bootstrap::<Empty, _>([], None);
+    let conf = bootstrap::<Empty, _>([]);
 
     tokio::spawn(async move {
         tokio::time::sleep(Duration::from_secs(20)).await;

--- a/examples/log-level-change/src/main.rs
+++ b/examples/log-level-change/src/main.rs
@@ -1,9 +1,8 @@
 use fregate::{
     axum::{routing::get, Router},
-    http_trace_layer, AppConfig, Application,
+    bootstrap, get_handle_log_layer, http_trace_layer, Application, Empty,
 };
 use std::str::FromStr;
-use std::sync::Arc;
 use std::time::Duration;
 use tracing_subscriber::EnvFilter;
 
@@ -12,13 +11,11 @@ use tracing_subscriber::EnvFilter;
 // Will be changed to TRACE
 #[tokio::main]
 async fn main() {
-    let conf = Arc::new(AppConfig::default());
+    let conf = bootstrap::<Empty, _>([], None);
 
-    let config = conf.clone();
     tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_secs(10)).await;
-        let config = config;
-        let log_filter_reloader = config.get_log_filter_reload().unwrap();
+        tokio::time::sleep(Duration::from_secs(20)).await;
+        let log_filter_reloader = get_handle_log_layer().unwrap();
 
         log_filter_reloader
             .modify(|filter| *filter.filter_mut() = EnvFilter::from_str("trace").unwrap())

--- a/examples/observability/src/main.rs
+++ b/examples/observability/src/main.rs
@@ -1,15 +1,17 @@
 use fregate::{
     axum::{routing::get, Router},
-    http_trace_layer, AppConfig, Application,
+    bootstrap, http_trace_layer, Application, Empty,
 };
 
 #[tokio::main]
 async fn main() {
+    let config = bootstrap::<Empty, _>([], None);
+
     let rest = Router::new()
         .route("/", get(handler))
         .layer(http_trace_layer());
 
-    Application::new(&AppConfig::default())
+    Application::new(&config)
         .router(rest)
         .serve()
         .await

--- a/examples/observability/src/main.rs
+++ b/examples/observability/src/main.rs
@@ -5,7 +5,7 @@ use fregate::{
 
 #[tokio::main]
 async fn main() {
-    let config = bootstrap::<Empty, _>([], None);
+    let config = bootstrap::<Empty, _>([]);
 
     let rest = Router::new()
         .route("/", get(handler))

--- a/examples/tonic/src/main.rs
+++ b/examples/tonic/src/main.rs
@@ -6,7 +6,7 @@ use fregate::axum::{
 };
 use fregate::hyper::Request;
 use fregate::tonic::{Request as TonicRequest, Response as TonicResponse, Status};
-use fregate::{grpc_trace_layer, http_trace_layer, AppConfig, Application, Tonicable};
+use fregate::{bootstrap, grpc_trace_layer, http_trace_layer, Application, Empty, Tonicable};
 use proto::{
     echo_server::{Echo, EchoServer},
     hello_server::{Hello, HelloServer},
@@ -58,7 +58,7 @@ async fn deny_middleware<B>(_req: Request<B>, _next: Next<B>) -> impl IntoRespon
 
 #[tokio::main]
 async fn main() {
-    let config = &AppConfig::default();
+    let config = bootstrap::<Empty, _>([], None);
 
     let echo_service = EchoServer::new(MyEcho);
     let hello_service = HelloServer::new(MyHello);
@@ -75,7 +75,7 @@ async fn main() {
 
     let app_router = rest.merge(grpc);
 
-    Application::new(config)
+    Application::new(&config)
         .router(app_router)
         .serve()
         .await

--- a/examples/tonic/src/main.rs
+++ b/examples/tonic/src/main.rs
@@ -58,7 +58,7 @@ async fn deny_middleware<B>(_req: Request<B>, _next: Next<B>) -> impl IntoRespon
 
 #[tokio::main]
 async fn main() {
-    let config = bootstrap::<Empty, _>([], None);
+    let config = bootstrap::<Empty, _>([]);
 
     let echo_service = EchoServer::new(MyEcho);
     let hello_service = HelloServer::new(MyHello);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,3 +8,37 @@ mod router;
 pub use self::metrics::*;
 pub(crate) use router::*;
 pub use {configuration::*, health::*, logging::*, proxy::*};
+
+use serde::de::DeserializeOwned;
+use std::fmt::Debug;
+use tracing::info;
+
+/// Reads AppConfig and initialise tracing.\
+/// Panic if fail to read AppConfig or initialise tracing.\
+/// Because of internal call to tracing_subscriber::registry().init() can't be called twice, otherwise panic.\
+/// Environment variables if set have highest priority in config hierarchy.
+pub fn bootstrap<'a, T, S>(sources: S, env_prefix: Option<&str>) -> AppConfig<T>
+where
+    S: IntoIterator<Item = ConfigSource<'a>>,
+    T: Debug + DeserializeOwned,
+{
+    let config = AppConfig::<T>::load_from(sources, env_prefix).expect("Failed to load AppConfig");
+
+    let LoggerConfig {
+        log_level,
+        trace_level,
+        service_name,
+        traces_endpoint,
+    } = &config.logger;
+
+    init_tracing(
+        log_level,
+        trace_level,
+        service_name,
+        traces_endpoint.as_deref(),
+    );
+
+    info!("Configuration: `{config:?}`.", config = config);
+
+    config
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,13 +16,12 @@ use tracing::info;
 /// Reads AppConfig and initialise tracing.\
 /// Panic if fail to read AppConfig or initialise tracing.\
 /// Because of internal call to tracing_subscriber::registry().init() can't be called twice, otherwise panic.\
-/// Environment variables if set have highest priority in config hierarchy.
-pub fn bootstrap<'a, T, S>(sources: S, env_prefix: Option<&str>) -> AppConfig<T>
+pub fn bootstrap<'a, T, S>(sources: S) -> AppConfig<T>
 where
     S: IntoIterator<Item = ConfigSource<'a>>,
     T: Debug + DeserializeOwned,
 {
-    let config = AppConfig::<T>::load_from(sources, env_prefix).expect("Failed to load AppConfig");
+    let config = AppConfig::<T>::load_from(sources).expect("Failed to load AppConfig");
 
     let LoggerConfig {
         log_level,

--- a/src/utils/configuration.rs
+++ b/src/utils/configuration.rs
@@ -20,6 +20,7 @@ const DEFAULT_SEPARATOR: &str = "_";
 pub enum ConfigSource<'a> {
     String(&'a str, FileFormat),
     File(&'a str),
+    EnvPrefix(&'a str),
 }
 
 #[derive(Deserialize, Debug, PartialEq, Eq, Copy, Clone)]
@@ -116,7 +117,7 @@ impl<T: DeserializeOwned + Debug> AppConfig<T> {
             .build()
     }
 
-    pub fn load_from<'a, S>(sources: S, env_prefix: Option<&str>) -> Result<Self, ConfigError>
+    pub fn load_from<'a, S>(sources: S) -> Result<Self, ConfigError>
     where
         S: IntoIterator<Item = ConfigSource<'a>>,
     {
@@ -128,11 +129,8 @@ impl<T: DeserializeOwned + Debug> AppConfig<T> {
             config_builder = match source {
                 ConfigSource::String(str, format) => config_builder.add_str(str, format),
                 ConfigSource::File(path) => config_builder.add_file(path),
+                ConfigSource::EnvPrefix(prefix) => config_builder.add_env_prefixed(prefix),
             };
-        }
-
-        if let Some(p) = env_prefix {
-            config_builder = config_builder.add_env_prefixed(p);
         }
 
         config_builder.build()

--- a/tests/app_config.rs
+++ b/tests/app_config.rs
@@ -28,17 +28,14 @@ mod app_config_tests {
     #[test]
     #[should_panic]
     fn no_file_found() {
-        let _config = AppConfig::<Empty>::load_from([ConfigSource::File("")], None)
+        let _config = AppConfig::<Empty>::load_from([ConfigSource::File("")])
             .expect("Failed to build AppConfig");
     }
 
     #[test]
     fn empty_str_file() {
-        let config = AppConfig::<Empty>::load_from(
-            [ConfigSource::String("", FileFormat::Toml)],
-            Some("TEST"),
-        )
-        .expect("Failed to build AppConfig");
+        let config = AppConfig::<Empty>::load_from([ConfigSource::String("", FileFormat::Toml)])
+            .expect("Failed to build AppConfig");
 
         assert_eq!(config.port, 8000);
         assert_eq!(config.host, IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)));
@@ -54,13 +51,10 @@ mod app_config_tests {
 
     #[test]
     fn read_str_from_file() {
-        let config = AppConfig::<Empty>::load_from(
-            [ConfigSource::String(
-                include_str!("resources/test_conf.toml"),
-                FileFormat::Toml,
-            )],
-            None,
-        )
+        let config = AppConfig::<Empty>::load_from([ConfigSource::String(
+            include_str!("resources/test_conf.toml"),
+            FileFormat::Toml,
+        )])
         .expect("Failed to build AppConfig");
 
         assert_eq!(config.port, 8888);
@@ -80,11 +74,9 @@ mod app_config_tests {
 
     #[test]
     fn read_file() {
-        let config = AppConfig::<Empty>::load_from(
-            [ConfigSource::File("./tests/resources/test_conf.toml")],
-            None,
-        )
-        .expect("Failed to build AppConfig");
+        let config =
+            AppConfig::<Empty>::load_from([ConfigSource::File("./tests/resources/test_conf.toml")])
+                .expect("Failed to build AppConfig");
 
         assert_eq!(config.port, 8888);
         assert_eq!(

--- a/tests/app_config.rs
+++ b/tests/app_config.rs
@@ -1,0 +1,103 @@
+mod app_config_tests {
+    use config::FileFormat;
+    use fregate::{AppConfig, ConfigSource, Empty};
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn multiple_config() {
+        let _config = AppConfig::default();
+        let _config = AppConfig::default();
+    }
+
+    #[test]
+    fn default() {
+        let config = AppConfig::default();
+
+        assert_eq!(config.port, 8000);
+        assert_eq!(config.host, IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)));
+        assert_eq!(config.private, Empty {});
+
+        let logger = config.logger;
+
+        assert_eq!(logger.traces_endpoint, None);
+        assert_eq!(logger.service_name, "Rust".to_owned());
+        assert_eq!(logger.trace_level, "info".to_owned());
+        assert_eq!(logger.log_level, "info".to_owned());
+    }
+
+    #[test]
+    #[should_panic]
+    fn no_file_found() {
+        let _config = AppConfig::<Empty>::load_from([ConfigSource::File("")], None)
+            .expect("Failed to build AppConfig");
+    }
+
+    #[test]
+    fn empty_str_file() {
+        let config = AppConfig::<Empty>::load_from(
+            [ConfigSource::String("", FileFormat::Toml)],
+            Some("TEST"),
+        )
+        .expect("Failed to build AppConfig");
+
+        assert_eq!(config.port, 8000);
+        assert_eq!(config.host, IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)));
+        assert_eq!(config.private, Empty {});
+
+        let logger = config.logger;
+
+        assert_eq!(logger.traces_endpoint, None);
+        assert_eq!(logger.service_name, "Rust".to_owned());
+        assert_eq!(logger.trace_level, "info".to_owned());
+        assert_eq!(logger.log_level, "info".to_owned());
+    }
+
+    #[test]
+    fn read_str_from_file() {
+        let config = AppConfig::<Empty>::load_from(
+            [ConfigSource::String(
+                include_str!("resources/test_conf.toml"),
+                FileFormat::Toml,
+            )],
+            None,
+        )
+        .expect("Failed to build AppConfig");
+
+        assert_eq!(config.port, 8888);
+        assert_eq!(
+            config.host,
+            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))
+        );
+        assert_eq!(config.private, Empty {});
+
+        let logger = config.logger;
+
+        assert_eq!(logger.traces_endpoint, None);
+        assert_eq!(logger.service_name, "Test".to_owned());
+        assert_eq!(logger.trace_level, "debug".to_owned());
+        assert_eq!(logger.log_level, "trace".to_owned());
+    }
+
+    #[test]
+    fn read_file() {
+        let config = AppConfig::<Empty>::load_from(
+            [ConfigSource::File("./tests/resources/test_conf.toml")],
+            None,
+        )
+        .expect("Failed to build AppConfig");
+
+        assert_eq!(config.port, 8888);
+        assert_eq!(
+            config.host,
+            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))
+        );
+        assert_eq!(config.private, Empty {});
+
+        let logger = config.logger;
+
+        assert_eq!(logger.traces_endpoint, None);
+        assert_eq!(logger.service_name, "Test".to_owned());
+        assert_eq!(logger.trace_level, "debug".to_owned());
+        assert_eq!(logger.log_level, "trace".to_owned());
+    }
+}

--- a/tests/app_config_from_env.rs
+++ b/tests/app_config_from_env.rs
@@ -1,0 +1,41 @@
+mod app_config_from_env {
+    use fregate::AppConfig;
+    use serde::Deserialize;
+    use std::net::{IpAddr, Ipv6Addr};
+
+    #[derive(Deserialize, Debug, PartialEq, Eq)]
+    pub struct TestStruct {
+        number: u32,
+    }
+
+    #[test]
+    fn test_load_from() {
+        std::env::set_var("TEST_HOST", "::1");
+        std::env::set_var("TEST_PORT", "1234");
+        std::env::set_var("TEST_SERVICE_NAME", "TEST");
+        std::env::set_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://0.0.0.0:4317");
+        std::env::set_var("TEST_TRACE_LEVEL", "debug");
+        std::env::set_var("TEST_LOG_LEVEL", "trace");
+        std::env::set_var("TEST_NUMBER", "100");
+
+        let config = AppConfig::<TestStruct>::load_from([], Some("TEST"))
+            .expect("Failed to build AppConfig");
+
+        assert_eq!(config.port, 1234);
+        assert_eq!(
+            config.host,
+            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))
+        );
+        assert_eq!(config.private, TestStruct { number: 100 });
+
+        let logger = config.logger;
+
+        assert_eq!(
+            logger.traces_endpoint,
+            Some("http://0.0.0.0:4317".to_owned())
+        );
+        assert_eq!(logger.service_name, "TEST".to_owned());
+        assert_eq!(logger.trace_level, "debug".to_owned());
+        assert_eq!(logger.log_level, "trace".to_owned());
+    }
+}

--- a/tests/app_config_from_env.rs
+++ b/tests/app_config_from_env.rs
@@ -1,5 +1,5 @@
 mod app_config_from_env {
-    use fregate::AppConfig;
+    use fregate::{AppConfig, ConfigSource};
     use serde::Deserialize;
     use std::net::{IpAddr, Ipv6Addr};
 
@@ -18,7 +18,7 @@ mod app_config_from_env {
         std::env::set_var("TEST_LOG_LEVEL", "trace");
         std::env::set_var("TEST_NUMBER", "100");
 
-        let config = AppConfig::<TestStruct>::load_from([], Some("TEST"))
+        let config = AppConfig::<TestStruct>::load_from([ConfigSource::EnvPrefix("TEST")])
             .expect("Failed to build AppConfig");
 
         assert_eq!(config.port, 1234);

--- a/tests/app_config_source_order.rs
+++ b/tests/app_config_source_order.rs
@@ -1,0 +1,22 @@
+mod app_config_source_order {
+    use fregate::{AppConfig, ConfigSource, Empty};
+
+    #[test]
+    fn test_load_from() {
+        std::env::set_var("TEST_PORT", "9999");
+
+        let config =
+            AppConfig::<Empty>::load_from([ConfigSource::File("./tests/resources/test_conf.toml")])
+                .expect("Failed to build AppConfig");
+
+        assert_eq!(config.port, 8888);
+
+        let config = AppConfig::<Empty>::load_from([
+            ConfigSource::File("./tests/resources/test_conf.toml"),
+            ConfigSource::EnvPrefix("TEST"),
+        ])
+        .expect("Failed to build AppConfig");
+
+        assert_eq!(config.port, 9999);
+    }
+}

--- a/tests/bootstrap.rs
+++ b/tests/bootstrap.rs
@@ -5,7 +5,7 @@ mod bootstrap_fn_test {
 
     #[tokio::test]
     async fn bootstrap_test() {
-        let config = bootstrap::<Empty, _>([], None);
+        let config = bootstrap::<Empty, _>([]);
 
         // bootstrap() fn internally spawns tasks, let's give it a little time
         tokio::time::sleep(Duration::from_millis(200)).await;

--- a/tests/bootstrap.rs
+++ b/tests/bootstrap.rs
@@ -1,0 +1,25 @@
+mod bootstrap_fn_test {
+    use fregate::{bootstrap, get_handle_log_layer, Empty};
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn bootstrap_test() {
+        let config = bootstrap::<Empty, _>([], None);
+
+        // bootstrap() fn internally spawns tasks, let's give it a little time
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        assert_eq!(config.port, 8000);
+        assert_eq!(config.host, IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)));
+        assert_eq!(config.private, Empty {});
+
+        let logger = config.logger;
+        assert_eq!(logger.traces_endpoint, None);
+        assert_eq!(logger.service_name, "Rust".to_owned());
+        assert_eq!(logger.trace_level, "info".to_owned());
+        assert_eq!(logger.log_level, "info".to_owned());
+
+        assert!(get_handle_log_layer().is_some());
+    }
+}

--- a/tests/bootstrap_multiple_calls.rs
+++ b/tests/bootstrap_multiple_calls.rs
@@ -4,7 +4,7 @@ mod multiple_bootstrap_calls {
     #[tokio::test]
     #[should_panic]
     async fn multiple_bootstrap_calls() {
-        let _config = bootstrap::<Empty, _>([], None);
-        let _config = bootstrap::<Empty, _>([], None);
+        let _config = bootstrap::<Empty, _>([]);
+        let _config = bootstrap::<Empty, _>([]);
     }
 }

--- a/tests/bootstrap_multiple_calls.rs
+++ b/tests/bootstrap_multiple_calls.rs
@@ -1,0 +1,10 @@
+mod multiple_bootstrap_calls {
+    use fregate::{bootstrap, Empty};
+
+    #[tokio::test]
+    #[should_panic]
+    async fn multiple_bootstrap_calls() {
+        let _config = bootstrap::<Empty, _>([], None);
+        let _config = bootstrap::<Empty, _>([], None);
+    }
+}

--- a/tests/resources/test_conf.toml
+++ b/tests/resources/test_conf.toml
@@ -1,0 +1,13 @@
+host = "::1"
+port = 8888
+
+[log]
+level = "trace"
+
+[trace]
+level = "debug"
+
+[service]
+name = "Test"
+
+[private]


### PR DESCRIPTION
Add bootstrap fn which takes IntoIterator<Item = ConfigSource>.
Where ConfigSource is enum:
```rust
pub enum ConfigSource<'a> {
    String(&'a str, FileFormat),
    File(&'a str),
    EnvPrefix(&'a str),
}
```

Inside will initialise tracing based on read AppConfig variables.
This is the only function that connect tracing and AppConfig
```rust
    let _conf: AppConfig<Empty> = bootstrap([
        ConfigSource::File("./examples/configuration/app.yaml"),
        ConfigSource::EnvPrefix("TEST"),
    ]);
```

AppConfig can be build  other ways which do not initialise tracing.
```rust
    let _conf = AppConfig::default();

    let _conf = AppConfig::<Empty>::builder()
        .add_default()
        .add_env_prefixed("TEST")
        .add_file("./examples/configuration/app.yaml")
        .add_str(include_str!("../app.yaml"), FileFormat::Yaml)
        .build()
        .unwrap();

    let _conf: AppConfig<Custom> =
        AppConfig::default_with("./examples/configuration/app.yaml", "TEST").unwrap();
```

Still available and does not depend on AppConfig public fn init_tracing():
```rust
pub fn init_tracing(
    log_level: &str,
    trace_level: &str,
    service_name: &str,
    traces_endpoint: Option<&str>,
)
```
