### PR TITLE
Disable default tls feature in opentelemetry-zipkin.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,13 +48,16 @@ opentelemetry-zipkin = "0.16.0"
 valuable = "0.1.0"
 valuable-serde = "0.1.0"
 
+# common deps for tls
 async-stream = { version = "0.3.3", optional = true }
 futures-util = { version = "0.3.25", optional = true }
-native-tls = { version = "0.2.10", optional = true, features = ["alpn"] }
-rustls-pemfile = { version = "1.0.1", optional = true }
-tokio-native-tls = { version = "0.3.0", optional = true }
-tokio-rustls = { version = "0.23.4", optional = true, default-features = false, features = ["logging"] }
 tokio-stream = { version = "0.1.11", optional = true, features = ["net"] }
+# native-tls deps
+native-tls = { version = "0.2.10", optional = true, features = ["alpn"] }
+tokio-native-tls = { version = "0.3.0", optional = true }
+# rustls deps
+rustls-pemfile = { version = "1.0.1", optional = true }
+tokio-rustls = { version = "0.23.4", optional = true, default-features = false, features = ["logging"] }
 
 [dev-dependencies]
 valuable-derive = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,15 +13,39 @@ keywords = ["http", "grpc", "service"]
 members = ["examples/*"]
 
 [features]
-native-tls = ["tokio-native-tls", "async-stream", "futures-util", "tokio/fs", "tokio/net", "tokio-stream"]
-native-tls-vendored = ["native-tls/vendored"]
-rustls = ["tokio-rustls", "rustls-pemfile", "async-stream", "futures-util", "tokio/fs", "tokio/net", "tokio-stream"]
-rustls-tls12 = ["rustls", "tokio-rustls/tls12"]
+native-tls = [
+    "reqwest/native-tls",
+    "tokio-native-tls",
+    "async-stream",
+    "futures-util",
+    "tokio/fs",
+    "tokio/net",
+    "tokio-stream"
+]
+native-tls-vendored = [
+    "reqwest/native-tls-vendored",
+    "native-tls/vendored"
+]
+rustls = [
+    "opentelemetry-zipkin/reqwest-rustls",
+    "tokio-rustls",
+    "rustls-pemfile",
+    "async-stream",
+    "futures-util",
+    "tokio/fs",
+    "tokio/net",
+    "tokio-stream"
+]
+rustls-tls12 = [
+    "rustls",
+    "tokio-rustls/tls12"
+]
 
 [dependencies]
 axum = { version = "0.5.7", features = ["headers", "http1", "http2", "json", "matched-path", "original-uri", "ws"] }
 bytes = "1"
 config = "0.13.1"
+reqwest = { version = "0.11", default-features = false, optional = true } # override opentelemetry-zipkin deps
 http-body = "0.4.4"
 hyper = { version = "0.14", features = ["full"] }
 thiserror = "1.0.31"
@@ -44,7 +68,7 @@ tracing-opentelemetry = "0.18.0"
 opentelemetry = { version = "0.18.0", features = ["rt-tokio"]}
 opentelemetry-otlp = { version = "0.11.0" }
 opentelemetry-http = "0.7.0"
-opentelemetry-zipkin = "0.16.0"
+opentelemetry-zipkin = { version = "0.16.0", default-features = false, features = ["reqwest-client"] }
 valuable = "0.1.0"
 valuable-serde = "0.1.0"
 

--- a/examples/examples_resources/src/proto/mod.rs
+++ b/examples/examples_resources/src/proto/mod.rs
@@ -1,6 +1,6 @@
-pub mod echo {
-    include!("echo.rs");
-}
 pub mod hello {
     include!("hello.rs");
+}
+pub mod echo {
+    include!("echo.rs");
 }

--- a/src/application/app.rs
+++ b/src/application/app.rs
@@ -92,17 +92,19 @@ impl<'a, H, T> Application<'a, H, T> {
             move |error| Error::CustomError(format!("Cant load TLS {type}: `{error}`."))
         }
 
-        let tls_handshake_timeout = self.config.tls_handshake_timeout;
+        let tls_handshake_timeout = self.config.tls.handshake_timeout;
 
         let tls_cert_path = self
             .config
-            .tls_cert_path
+            .tls
+            .cert_path
             .as_deref()
             .ok_or_else(|| cant_load("certificate")("No path present."))?;
 
         let tls_key_path = self
             .config
-            .tls_key_path
+            .tls
+            .key_path
             .as_deref()
             .ok_or_else(|| cant_load("key")("No path present."))?;
 

--- a/src/application/configuration/tls.rs
+++ b/src/application/configuration/tls.rs
@@ -1,0 +1,42 @@
+use crate::extensions::DeserializeExt;
+use serde::{Deserialize, Deserializer};
+use serde_json::Value;
+use std::time::Duration;
+
+const TLS_HANDSHAKE_TIMEOUT: &str = "/server/tls/handshake_timeout";
+const TLS_KEY_PATH: &str = "/server/tls/key/path";
+const TLS_CERTIFICATE_PATH: &str = "/server/tls/cert/path";
+
+#[derive(Debug)]
+pub struct TlsConfigurationVariables {
+    /// TLS handshake timeout
+    pub handshake_timeout: Duration,
+    /// path to TLS key file
+    pub key_path: Option<Box<str>>,
+    /// path to TLS certificate file
+    pub cert_path: Option<Box<str>>,
+}
+
+impl<'de> Deserialize<'de> for TlsConfigurationVariables {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let config = Value::deserialize(deserializer)?;
+
+        let tls_handshake_timeout =
+            config.pointer_and_deserialize::<u64, D::Error>(TLS_HANDSHAKE_TIMEOUT)?;
+        let tls_key_path = config
+            .pointer_and_deserialize::<_, D::Error>(TLS_KEY_PATH)
+            .ok();
+        let tls_cert_path = config
+            .pointer_and_deserialize::<_, D::Error>(TLS_CERTIFICATE_PATH)
+            .ok();
+
+        Ok(Self {
+            handshake_timeout: Duration::from_millis(tls_handshake_timeout),
+            key_path: tls_key_path,
+            cert_path: tls_cert_path,
+        })
+    }
+}

--- a/tests/app_config_tls.rs
+++ b/tests/app_config_tls.rs
@@ -17,8 +17,8 @@ mod app_config_tls {
     async fn tls_paths() {
         let config = AppConfig::default();
 
-        assert!(config.tls_key_path.is_none());
-        assert!(config.tls_cert_path.is_none());
+        assert!(config.tls.key_path.is_none());
+        assert!(config.tls.cert_path.is_none());
         assert!(Application::new(&config).serve_tls().await.is_err());
 
         std::env::set_var("TEST_SERVER_TLS_KEY_PATH", TLS_KEY_FULL_PATH);
@@ -28,8 +28,8 @@ mod app_config_tls {
             .build()
             .unwrap();
 
-        assert!(config.tls_key_path.is_some());
-        assert!(config.tls_cert_path.is_none());
+        assert!(config.tls.key_path.is_some());
+        assert!(config.tls.cert_path.is_none());
         assert!(Application::new(&config).serve_tls().await.is_err());
 
         std::env::set_var("TEST_SERVER_TLS_CERT_PATH", TLS_CERTIFICATE_FULL_PATH);
@@ -39,8 +39,8 @@ mod app_config_tls {
             .build()
             .unwrap();
 
-        assert!(config.tls_key_path.is_some());
-        assert!(config.tls_cert_path.is_some());
+        assert!(config.tls.key_path.is_some());
+        assert!(config.tls.cert_path.is_some());
         assert!(timeout(
             Duration::from_secs(2),
             Application::new(&config).serve_tls(),

--- a/tests/tls.rs
+++ b/tests/tls.rs
@@ -61,7 +61,7 @@ mod tls {
             .unwrap();
 
         let port = get_free_port().await;
-        let tls_timeout = config.tls_handshake_timeout;
+        let tls_timeout = config.tls.handshake_timeout;
 
         tokio::task::spawn(async move {
             config.port = port;


### PR DESCRIPTION
By default, `open-telemetry-zipkin` crate enable TLS which use `native-tls`. 
Better let the user decide it's needed TLS and which implementation he wants to use (`native-tls` or `rustls`).