### PR TITLE
add opentelemtry global error to print exporter error through tracing…

### DIFF
--- a/src/application/error.rs
+++ b/src/application/error.rs
@@ -32,7 +32,9 @@ pub enum Error {
     /// Some std IO Error
     #[error("Got IoError: `{0}`")]
     IoError(#[from] std::io::Error),
-
+    /// Variant for [`opentelemetry::global::Error`]
+    #[error("Got OpentelemetryError: `{0}`")]
+    OpentelemetryError(#[from] opentelemetry::global::Error),
     /// tokio JoinHandle error
     #[cfg(feature = "tls")]
     #[error("Got JoinHandleError: `{0}`")]

--- a/src/application/logging.rs
+++ b/src/application/logging.rs
@@ -2,6 +2,7 @@
 use crate::error::Result;
 use crate::log_fmt::{fregate_layer, EventFormatter, COMPONENT, SERVICE, VERSION};
 use once_cell::sync::OnceCell;
+use opentelemetry::global::set_error_handler;
 use opentelemetry::{global, sdk, sdk::Resource, KeyValue};
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_zipkin::B3Encoding::MultipleHeader;
@@ -126,6 +127,9 @@ pub fn init_tracing(
     registry().with(trace_layer).with(log_layer).try_init()?;
     let _ = HANDLE_LOG_LAYER.get_or_init(|| reload_log_filter);
 
+    set_error_handler(|err| {
+        tracing::error!("{err}");
+    })?;
     set_panic_hook();
 
     Ok(())


### PR DESCRIPTION
exporter error will be printed throug tracing::error!
ex:
```json
{"component":"client","service":"fregate","version":"0.0.0","msg":"Exporter otlp encountered the following error(s): the grpc server returns error (The service is currently unavailable): , detailed error message: error trying to connect: tcp connect error: Connection refused (os error 61)","target":"fregate::application::logging","LogLevel":"ERROR","time":1669096465133035000,"timestamp":"2022-11-22T05:54:25.133Z"}
```