### PR TITLE
Limit msg field in log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,13 @@ rustls-pemfile = { version = "1.0.1", optional = true }
 tokio-rustls = { version = "0.23.4", optional = true, default-features = false, features = ["logging"] }
 
 [dev-dependencies]
+tracing-subscriber = { version = "0.3.11", features = ["env-filter", "json", "time"] }
 valuable-derive = "0.1.0"
 rustls = { version = "0.20.7", features = ["tls12", "dangerous_configuration"] }
 hyper-rustls = { version = "0.23.0", default-features = false, features = ["native-tokio", "http1", "tls12"] }
 tokio = { version = "1.22.0", features = ["rt-multi-thread"] }
+criterion = "0.4"
+
+[[bench]]
+name = "log_filter"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,5 +98,5 @@ tokio = { version = "1.22.0", features = ["rt-multi-thread"] }
 criterion = "0.4"
 
 [[bench]]
-name = "log_filter"
+name = "log_fmt"
 harness = false

--- a/benches/log_filter.rs
+++ b/benches/log_filter.rs
@@ -1,0 +1,118 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use fregate::log_fmt::EventFormatter;
+use std::collections::hash_map::RandomState;
+use std::collections::HashMap;
+use std::io;
+use time::format_description::well_known::Rfc3339;
+use tracing::subscriber::with_default;
+use tracing_subscriber::fmt::format::{DefaultFields, Format, Json, JsonFields};
+use tracing_subscriber::fmt::time::UtcTime;
+use tracing_subscriber::fmt::{MakeWriter, Subscriber};
+use tracing_subscriber::EnvFilter;
+
+fn benchmark(c: &mut Criterion) {
+    let i = 1000;
+    let data = HashMap::<_, _, RandomState>::from_iter(
+        [
+            ("secret".to_owned(), "Debug Secret".to_owned()),
+            ("random data".to_owned(), "random data".to_owned()),
+        ]
+        .into_iter(),
+    );
+
+    let mut group = c.benchmark_group("Logging");
+
+    group.bench_with_input(
+        BenchmarkId::new("Tracing Subscriber Json Event Formatter", i),
+        &(i, &data),
+        |b, (i, data)| {
+            let subscriber = tracing_subscriber();
+
+            with_default(subscriber, || {
+                b.iter(|| {
+                    for _ in 0..*i {
+                        tracing::info!(data = ?data, secret = "12345", "message");
+                    }
+                });
+            });
+        },
+    );
+    group.bench_with_input(
+        BenchmarkId::new("Fregate Event Formatter No Limits", i),
+        &(i, &data),
+        |b, (i, data)| {
+            let subscriber = subscriber(EventFormatter::new_no_limits());
+
+            with_default(subscriber, || {
+                b.iter(|| {
+                    for _ in 0..*i {
+                        tracing::info!(data = ?data, secret = "12345", "message");
+                    }
+                });
+            });
+        },
+    );
+    group.finish();
+}
+
+criterion_group!(benches, benchmark);
+criterion_main!(benches);
+
+#[derive(Clone, Debug)]
+struct MockWriter;
+
+#[derive(Clone, Debug)]
+struct MakeMockWriter;
+
+impl MakeMockWriter {
+    fn new() -> Self {
+        Self {}
+    }
+}
+
+impl MockWriter {
+    fn new() -> Self {
+        Self {}
+    }
+}
+
+impl io::Write for MockWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for MakeMockWriter {
+    type Writer = MockWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        MockWriter::new()
+    }
+}
+
+fn subscriber(
+    formatter: EventFormatter,
+) -> Subscriber<DefaultFields, EventFormatter, EnvFilter, MakeMockWriter> {
+    Subscriber::builder()
+        .event_format(formatter)
+        .with_writer(MakeMockWriter::new())
+        .with_env_filter("info")
+        .finish()
+}
+
+fn tracing_subscriber(
+) -> Subscriber<JsonFields, Format<Json, UtcTime<Rfc3339>>, EnvFilter, MakeMockWriter> {
+    tracing_subscriber::fmt()
+        .json()
+        .with_timer::<_>(UtcTime::rfc_3339())
+        .with_writer(MakeMockWriter::new())
+        .flatten_event(true)
+        .with_target(true)
+        .with_current_span(false)
+        .with_env_filter("info")
+        .finish()
+}

--- a/examples/grafana/src/client.rs
+++ b/examples/grafana/src/client.rs
@@ -50,7 +50,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "client",
         Some("http://0.0.0.0:4317"),
         None,
-        None,
     )
     .unwrap();
 

--- a/examples/grafana/src/client.rs
+++ b/examples/grafana/src/client.rs
@@ -49,6 +49,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "fregate",
         "client",
         Some("http://0.0.0.0:4317"),
+        None,
+        None,
     )
     .unwrap();
 

--- a/src/application/bootstrap.rs
+++ b/src/application/bootstrap.rs
@@ -43,7 +43,6 @@ where
         service_name,
         component_name,
         traces_endpoint,
-        length,
         msg_length,
         ..
     } = &config.logger;
@@ -55,8 +54,7 @@ where
         service_name,
         component_name,
         traces_endpoint.as_deref(),
-        length.clone(),
-        msg_length.clone(),
+        *msg_length,
     )?;
 
     init_metrics()?;

--- a/src/application/bootstrap.rs
+++ b/src/application/bootstrap.rs
@@ -43,6 +43,8 @@ where
         service_name,
         component_name,
         traces_endpoint,
+        length,
+        msg_length,
         ..
     } = &config.logger;
 
@@ -53,6 +55,8 @@ where
         service_name,
         component_name,
         traces_endpoint.as_deref(),
+        length.clone(),
+        msg_length.clone(),
     )?;
 
     init_metrics()?;

--- a/src/application/configuration.rs
+++ b/src/application/configuration.rs
@@ -24,7 +24,6 @@ const PORT_PTR: &str = "/port";
 #[cfg(feature = "tokio-metrics")]
 const SERVER_METRICS_UPDATE_INTERVAL: &str = "/server/metrics/update_interval";
 const LOG_LEVEL_PTR: &str = "/log/level";
-const LOG_LENGTH: &str = "/log/length";
 const LOG_MSG_LENGTH: &str = "/log/msg/length";
 const TRACE_LEVEL_PTR: &str = "/trace/level";
 const SERVICE_NAME_PTR: &str = "/service/name";
@@ -70,9 +69,7 @@ pub struct AppConfig<T> {
 pub struct LoggerConfig {
     /// log level read to string and later parsed into EnvFilter
     pub log_level: String,
-    /// Maximum log message length, if set: log message will be cut dirtily from its end
-    pub length: Option<usize>,
-    /// Maximum message field length, if set: message field will be cut dirtily from its end
+    /// Maximum message field length, if set: message field will be cut if len() exceed this limit
     pub msg_length: Option<usize>,
     /// trace level read to string and later parsed into EnvFilter
     pub trace_level: String,
@@ -110,16 +107,12 @@ impl<'de> Deserialize<'de> for LoggerConfig {
         #[cfg(feature = "tokio-metrics")]
         let metrics_update_interval =
             config.pointer_and_deserialize::<u64, D::Error>(SERVER_METRICS_UPDATE_INTERVAL)?;
-        let length = config
-            .pointer_and_deserialize::<_, D::Error>(LOG_LENGTH)
-            .ok();
         let msg_length = config
             .pointer_and_deserialize::<_, D::Error>(LOG_MSG_LENGTH)
             .ok();
 
         Ok(LoggerConfig {
             log_level,
-            length,
             msg_length,
             version,
             trace_level,

--- a/src/application/configuration.rs
+++ b/src/application/configuration.rs
@@ -24,6 +24,8 @@ const PORT_PTR: &str = "/port";
 #[cfg(feature = "tokio-metrics")]
 const SERVER_METRICS_UPDATE_INTERVAL: &str = "/server/metrics/update_interval";
 const LOG_LEVEL_PTR: &str = "/log/level";
+const LOG_LENGTH: &str = "/log/length";
+const LOG_MSG_LENGTH: &str = "/log/msg/length";
 const TRACE_LEVEL_PTR: &str = "/trace/level";
 const SERVICE_NAME_PTR: &str = "/service/name";
 const COMPONENT_NAME_PTR: &str = "/component/name";
@@ -68,6 +70,10 @@ pub struct AppConfig<T> {
 pub struct LoggerConfig {
     /// log level read to string and later parsed into EnvFilter
     pub log_level: String,
+    /// Maximum log message length, if set: log message will be cut dirtily from its end
+    pub length: Option<usize>,
+    /// Maximum message field length, if set: message field will be cut dirtily from its end
+    pub msg_length: Option<usize>,
     /// trace level read to string and later parsed into EnvFilter
     pub trace_level: String,
     /// service name to be used in logs
@@ -104,9 +110,17 @@ impl<'de> Deserialize<'de> for LoggerConfig {
         #[cfg(feature = "tokio-metrics")]
         let metrics_update_interval =
             config.pointer_and_deserialize::<u64, D::Error>(SERVER_METRICS_UPDATE_INTERVAL)?;
+        let length = config
+            .pointer_and_deserialize::<_, D::Error>(LOG_LENGTH)
+            .ok();
+        let msg_length = config
+            .pointer_and_deserialize::<_, D::Error>(LOG_MSG_LENGTH)
+            .ok();
 
         Ok(LoggerConfig {
             log_level,
+            length,
+            msg_length,
             version,
             trace_level,
             service_name,

--- a/src/application/log_fmt.rs
+++ b/src/application/log_fmt.rs
@@ -86,6 +86,30 @@ impl EventFormatter {
     }
 
     /// Creates new [`EventFormatter`] with limits for msg field
+    /// Example:
+    /// ```rust
+    ///  use fregate::log_fmt::{fregate_layer, EventFormatter};
+    ///  use std::str::FromStr;
+    ///  use tracing::info;
+    ///  use tracing_subscriber::layer::SubscriberExt;
+    ///  use tracing_subscriber::util::SubscriberInitExt;
+    ///  use tracing_subscriber::{registry, EnvFilter, Layer};
+    ///  
+    ///  #[tokio::main]
+    ///  async fn main() {
+    ///      let log_layer = fregate_layer(EventFormatter::new_with_limits(Some(1)));
+    ///  
+    ///      registry()
+    ///          .with(log_layer.with_filter(EnvFilter::from_str("info").unwrap()))
+    ///          .init();
+    ///  
+    ///      info!("message");
+    ///  }
+    /// ```
+    /// Will print next log message:
+    /// ```json
+    /// {"time":1673608228799729000,"timestamp":"2023-01-13T11:10:28.800Z","LogLevel":"INFO","target":"playground","msg":"m ..."}
+    /// ```
     pub fn new_with_limits(msg_len: Option<usize>) -> Self {
         Self {
             additional_fields: Default::default(),

--- a/src/application/log_fmt.rs
+++ b/src/application/log_fmt.rs
@@ -1,9 +1,9 @@
 //! Fregate [`FormatEvent`] trait implementation
-use crate::error::Result;
+use crate::error::{Error, Result};
 use opentelemetry::trace::{SpanId, TraceContextExt};
 use serde::{ser::SerializeMap, Serialize, Serializer};
 use serde_json::Value;
-use std::{collections::BTreeMap, fmt, num::NonZeroU8};
+use std::{collections::BTreeMap, fmt, mem, num::NonZeroU8};
 use time::format_description::well_known::iso8601::{Config, Iso8601, TimePrecision};
 use tracing::{field::Field, Event, Subscriber};
 use tracing_opentelemetry::OtelData;
@@ -55,8 +55,8 @@ where
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     let mut formatter = EventFormatter::new();
-///     formatter.add_field_to_events("test", vec![0, 1]).unwrap();
+///     let mut formatter = EventFormatter::new_no_limits();
+///     formatter.add_field_to_events("additional_field", "additional_value").unwrap();
 ///     registry().with(fregate_layer(formatter)).init();
 ///
 ///     info!("info message");
@@ -67,20 +67,46 @@ where
 ///```
 ///
 ///```json
-/// {"test":[0,1],"msg":"info message","target":"check_fregate","LogLevel":"INFO","time":1665672717498107000,"timestamp":"2022-10-13T14:51:57.498Z"}
-/// {"test":[0,1],"msg":"info message","target":"check_fregate","LogLevel":"DEBUG","time":1665672717498210000,"timestamp":"2022-10-13T14:51:57.498Z"}
-/// {"test":[0,1],"msg":"info message","target":"check_fregate","LogLevel":"TRACE","time":1665672717498247000,"timestamp":"2022-10-13T14:51:57.498Z"}
-/// {"test":[0,1],"msg":"info message","target":"check_fregate","LogLevel":"WARN","time":1665672717498279000,"timestamp":"2022-10-13T14:51:57.498Z"}
+/// {"additional_field":"additional_value","msg":"info message","target":"check_fregate","LogLevel":"INFO","time":1665672717498107000,"timestamp":"2022-10-13T14:51:57.498Z"}
+/// {"additional_field":"additional_value","msg":"info message","target":"check_fregate","LogLevel":"DEBUG","time":1665672717498210000,"timestamp":"2022-10-13T14:51:57.498Z"}
+/// {"additional_field":"additional_value","msg":"info message","target":"check_fregate","LogLevel":"TRACE","time":1665672717498247000,"timestamp":"2022-10-13T14:51:57.498Z"}
+/// {"additional_field":"additional_value","msg":"info message","target":"check_fregate","LogLevel":"WARN","time":1665672717498279000,"timestamp":"2022-10-13T14:51:57.498Z"}
 /// ```
-#[derive(Debug, Default)]
+#[derive(Debug, Clone)]
 pub struct EventFormatter {
-    default_fields: BTreeMap<String, Value>,
+    additional_fields: BTreeMap<String, Value>,
+    max_log_len: Option<usize>,
+    max_msg_len: Option<usize>,
 }
 
 impl EventFormatter {
-    /// Creates new [`EventFormatter`]
-    pub fn new() -> Self {
-        Self::default()
+    /// Creates new [`EventFormatter`], returns Error if max_log_len < max_msg_len
+    pub fn new(max_log_len: Option<usize>, max_msg_len: Option<usize>) -> Result<Self> {
+        let is_correct = match (max_log_len, max_msg_len) {
+            (Some(max_log_len), Some(max_msg_len)) => max_log_len >= max_msg_len,
+            _ => true,
+        };
+
+        if !is_correct {
+            Err(Error::CustomError(
+                "Max log len should size should be >= max msg len.".to_owned(),
+            ))
+        } else {
+            Ok(Self {
+                additional_fields: Default::default(),
+                max_log_len,
+                max_msg_len,
+            })
+        }
+    }
+
+    /// This is equal to call [`EventFormatter::new(None, None)`] but it skip check
+    pub fn new_no_limits() -> Self {
+        Self {
+            additional_fields: Default::default(),
+            max_log_len: None,
+            max_msg_len: None,
+        }
     }
 
     /// add key-value pair which will be added to all events\
@@ -100,8 +126,8 @@ impl EventFormatter {
     /// ```
     pub fn add_field_to_events<V: Serialize>(&mut self, key: &str, value: V) -> Result<()> {
         if DEFAULT_FIELDS.contains(&key) {
-            Err(crate::error::Error::CustomError(format!(
-                "Prohibited to add key: {key} to EventFormatter"
+            Err(Error::CustomError(format!(
+                "Prohibited to add key: '{key}' to EventFormatter"
             )))
         } else {
             self.add_default_field_to_events(key, value)
@@ -114,8 +140,12 @@ impl EventFormatter {
         value: V,
     ) -> Result<()> {
         let val = serde_json::to_value(value)?;
-        self.default_fields.insert(key.to_owned(), val);
+        self.additional_fields.insert(key.to_owned(), val);
         Ok(())
+    }
+
+    fn fields_len(&self) -> usize {
+        self.additional_fields.len()
     }
 }
 
@@ -130,29 +160,37 @@ where
         mut writer: format::Writer<'_>,
         event: &Event<'_>,
     ) -> fmt::Result {
+        const AVERAGE_MESSAGE_LEN: usize = 512;
+
         let serialize = || {
-            let mut buf = Vec::with_capacity(event.fields().count());
+            let event_fields_len = event.fields().count();
+            let total_fields_len = DEFAULT_FIELDS.len() + self.fields_len() + event_fields_len;
+
+            let mut buf = Vec::with_capacity(AVERAGE_MESSAGE_LEN);
             let mut serializer = serde_json::Serializer::new(&mut buf);
-            let mut map_serializer = serializer.serialize_map(None).unwrap();
+            let mut map_serializer = serializer.serialize_map(Some(total_fields_len)).unwrap();
 
-            let mut visitor = JsonVisitor::default();
+            let mut visitor = JsonVisitor::new();
             event.record(&mut visitor);
+            let mut event_storage = visitor.storage;
 
-            // serialize default fields
-            self.default_fields
+            // serialize additional fields
+            self.additional_fields
                 .iter()
                 .try_for_each(|(key, value)| map_serializer.serialize_entry(key, value))?;
 
-            // serialize event fields
-            let mut event_storage = visitor.storage;
-            let message = event_storage.remove(MESSAGE).unwrap_or_default();
+            // serialize message field
+            let mut message = event_storage.remove(MESSAGE).unwrap_or_default();
+            self.max_msg_len
+                .map(|limit| limit_str_value(&mut message, limit));
             map_serializer.serialize_entry(MSG, &message)?;
 
+            // serialize event fields
             event_storage
                 .iter()
                 .filter(|(key, _)| {
                     !DEFAULT_FIELDS.contains(&key.as_str())
-                        && !self.default_fields.contains_key(key.as_str())
+                        && !self.additional_fields.contains_key(key.as_str())
                 })
                 .try_for_each(|(key, value)| map_serializer.serialize_entry(key, value))?;
 
@@ -179,7 +217,7 @@ where
                 map_serializer.serialize_entry(SPAN_ID, &span_id.to_string())?;
             }
 
-            // serialize current event metadata
+            // serialize event metadata\
             let metadata = event.metadata();
             map_serializer.serialize_entry(TARGET, metadata.target())?;
             map_serializer.serialize_entry(LOG_LEVEL, metadata.level().as_str())?;
@@ -211,6 +249,7 @@ where
 
         match result {
             Ok(formatted) => {
+                // todo: check here total length
                 write!(writer, "{}", String::from_utf8_lossy(&formatted))?;
             }
             Err(err) => {
@@ -228,24 +267,31 @@ struct JsonVisitor {
 }
 
 impl JsonVisitor {
-    fn insert<T: Serialize>(&mut self, key: &str, value: T) {
-        self.storage
-            .insert(key.to_owned(), serde_json::json!(value));
+    fn new() -> Self {
+        Self {
+            storage: BTreeMap::new(),
+        }
+    }
+
+    fn insert<T: Serialize>(&mut self, key: impl Into<String>, value: T) {
+        let value = serde_json::json!(value);
+        self.storage.insert(key.into(), value);
     }
 }
 
 impl tracing::field::Visit for JsonVisitor {
     #[cfg(tracing_unstable)]
     fn record_value(&mut self, field: &Field, value: valuable::Value<'_>) {
-        let serde_value = serde_json::json!(Serializable::new(value));
-        let structurable = value.as_structable();
+        let mut serde_value = serde_json::json!(Serializable::new(value));
+        let structure = value.as_structable();
 
-        if let Some(structurable) = structurable {
-            let definition = structurable.definition();
+        if let Some(structure) = structure {
+            let definition = structure.definition();
 
-            if definition.is_dynamic() && definition.name() == TRACING_FIELDS_STRUCTURE_NAME {
-                match serde_value.as_object() {
+            if definition.name() == TRACING_FIELDS_STRUCTURE_NAME {
+                match serde_value.as_object_mut() {
                     Some(value) => {
+                        let value = mem::take(value);
                         value.into_iter().for_each(|(k, v)| {
                             self.insert(k.as_str(), v);
                         });
@@ -258,7 +304,7 @@ impl tracing::field::Visit for JsonVisitor {
             }
         }
 
-        self.insert(field.name(), serde_value);
+        self.insert(field.name(), serde_value)
     }
 
     fn record_f64(&mut self, field: &Field, value: f64) {
@@ -294,5 +340,44 @@ impl tracing::field::Visit for JsonVisitor {
                 self.insert(name, format!("{:?}", value));
             }
         };
+    }
+}
+
+// TODO: remove when done
+// https://github.com/rust-lang/rust/issues/93743
+mod round {
+    pub(crate) fn floor_char_boundary(val: &str, index: usize) -> usize {
+        if index >= val.len() {
+            val.len()
+        } else {
+            let lower_bound = index.saturating_sub(3);
+            let new_index = val.as_bytes()[lower_bound..=index]
+                .iter()
+                .rposition(|b| is_utf8_char_boundary(*b));
+
+            let new_index = match new_index {
+                Some(val) => val,
+                None => unreachable!("floor_char_boundary fn should never fail"),
+            };
+
+            lower_bound + new_index
+        }
+    }
+
+    #[inline]
+    const fn is_utf8_char_boundary(byte: u8) -> bool {
+        (byte as i8) >= -0x40
+    }
+}
+
+fn limit_str_value(value: &mut Value, limit: usize) {
+    match value {
+        Value::String(str) => {
+            if str.len() > limit {
+                let new_limit = round::floor_char_boundary(str, limit);
+                str.replace_range(new_limit..str.len(), " ...");
+            }
+        }
+        _ => {}
     }
 }

--- a/src/application/logging.rs
+++ b/src/application/logging.rs
@@ -94,8 +94,9 @@ pub fn init_tracing(
     service_name: &str,
     component_name: &str,
     traces_endpoint: Option<&str>,
+    log_msg_length: Option<usize>,
 ) -> Result<()> {
-    let mut formatter = EventFormatter::new_no_limits();
+    let mut formatter = EventFormatter::new_with_limits(log_msg_length)?;
 
     formatter.add_default_field_to_events(VERSION, version)?;
     formatter.add_default_field_to_events(SERVICE, service_name)?;

--- a/src/application/logging.rs
+++ b/src/application/logging.rs
@@ -95,7 +95,7 @@ pub fn init_tracing(
     component_name: &str,
     traces_endpoint: Option<&str>,
 ) -> Result<()> {
-    let mut formatter = EventFormatter::new();
+    let mut formatter = EventFormatter::new_no_limits();
 
     formatter.add_default_field_to_events(VERSION, version)?;
     formatter.add_default_field_to_events(SERVICE, service_name)?;

--- a/src/application/logging.rs
+++ b/src/application/logging.rs
@@ -96,7 +96,7 @@ pub fn init_tracing(
     traces_endpoint: Option<&str>,
     log_msg_length: Option<usize>,
 ) -> Result<()> {
-    let mut formatter = EventFormatter::new_with_limits(log_msg_length)?;
+    let mut formatter = EventFormatter::new_with_limits(log_msg_length);
 
     formatter.add_default_field_to_events(VERSION, version)?;
     formatter.add_default_field_to_events(SERVICE, service_name)?;

--- a/src/application/tracing_fields.rs
+++ b/src/application/tracing_fields.rs
@@ -18,7 +18,7 @@ pub(crate) const TRACING_FIELDS_STRUCTURE_NAME: &str =
 ///
 /// #[tokio::main]
 /// async fn main() {
-///    init_tracing("info", "info", "0.0.0", "fregate", "marker", None, None, None).unwrap();
+///    init_tracing("info", "info", "0.0.0", "fregate", "marker", None, None).unwrap();
 ///
 ///    let mut marker = TracingFields::with_capacity(10);
 ///

--- a/src/application/tracing_fields.rs
+++ b/src/application/tracing_fields.rs
@@ -18,7 +18,7 @@ pub(crate) const TRACING_FIELDS_STRUCTURE_NAME: &str =
 ///
 /// #[tokio::main]
 /// async fn main() {
-///    init_tracing("info", "info", "0.0.0", "fregate", "marker", None).unwrap();
+///    init_tracing("info", "info", "0.0.0", "fregate", "marker", None, None, None).unwrap();
 ///
 ///    let mut marker = TracingFields::with_capacity(10);
 ///

--- a/src/resources/default_conf.toml
+++ b/src/resources/default_conf.toml
@@ -8,6 +8,10 @@ port = 8000
 
 [log]
 level = "info"
+length = 16384 #in bytes
+
+[log.msg]
+length = 8192 #in bytes
 
 [trace]
 level = "info"

--- a/src/resources/default_conf.toml
+++ b/src/resources/default_conf.toml
@@ -8,7 +8,6 @@ port = 8000
 
 [log]
 level = "info"
-length = 16384 #in bytes
 
 [log.msg]
 length = 8192 #in bytes

--- a/tests/app_config.rs
+++ b/tests/app_config.rs
@@ -25,7 +25,6 @@ mod app_config_tests {
         assert_eq!(logger.component_name, "example".to_owned());
         assert_eq!(logger.trace_level, "info".to_owned());
         assert_eq!(logger.log_level, "info".to_owned());
-        assert_eq!(logger.length, Some(16384));
         assert_eq!(logger.msg_length, Some(8192));
     }
 

--- a/tests/app_config.rs
+++ b/tests/app_config.rs
@@ -25,6 +25,8 @@ mod app_config_tests {
         assert_eq!(logger.component_name, "example".to_owned());
         assert_eq!(logger.trace_level, "info".to_owned());
         assert_eq!(logger.log_level, "info".to_owned());
+        assert_eq!(logger.length, Some(16384));
+        assert_eq!(logger.msg_length, Some(8192));
     }
 
     #[test]

--- a/tests/app_config_from_env.rs
+++ b/tests/app_config_from_env.rs
@@ -15,11 +15,10 @@ mod app_config_from_env {
         std::env::set_var("TEST_SERVICE_NAME", "TEST");
         std::env::set_var("TEST_COMPONENT_NAME", "COMPONENT_TEST");
         std::env::set_var("TEST_COMPONENT_VERSION", "1.0.0");
-        std::env::set_var("TEST_LOG_LENGTH", "300");
-        std::env::set_var("TEST_LOG_MSG_LENGTH", "0");
         std::env::set_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://0.0.0.0:4317");
         std::env::set_var("TEST_TRACE_LEVEL", "debug");
         std::env::set_var("TEST_LOG_LEVEL", "trace");
+        std::env::set_var("TEST_LOG_MSG_LENGTH", "0");
         std::env::set_var("TEST_NUMBER", "100");
 
         let config = AppConfig::<TestStruct>::load_from([ConfigSource::EnvPrefix("TEST")])
@@ -44,27 +43,26 @@ mod app_config_from_env {
         assert_eq!(logger.service_name, "TEST".to_owned());
         assert_eq!(logger.trace_level, "debug".to_owned());
         assert_eq!(logger.log_level, "trace".to_owned());
-        assert_eq!(logger.length, Some(300));
         assert_eq!(logger.msg_length, Some(0));
     }
 
     #[test]
     #[should_panic]
-    fn negative_log_length() {
-        std::env::set_var("WRONG_LOG_LENGTH", "-123");
-        let config = AppConfig::<TestStruct>::load_from([ConfigSource::EnvPrefix("TEST")])
+    fn negative_msg_length() {
+        std::env::set_var("WRONG_LOG_MSG_LENGTH", "-123");
+        let config = AppConfig::<TestStruct>::load_from([ConfigSource::EnvPrefix("WRONG")])
             .expect("Failed to build AppConfig");
 
-        assert_eq!(config.logger.length, None);
+        assert_eq!(config.logger.msg_length, None);
     }
 
     #[test]
     #[should_panic]
-    fn wrong_log_length() {
-        std::env::set_var("WRONG_LOG_LENGTH", "1a123");
-        let config = AppConfig::<TestStruct>::load_from([ConfigSource::EnvPrefix("TEST")])
+    fn wrong_msg_length() {
+        std::env::set_var("WRONG_LOG_MSG_LENGTH", "1a123");
+        let config = AppConfig::<TestStruct>::load_from([ConfigSource::EnvPrefix("WRONG")])
             .expect("Failed to build AppConfig");
 
-        assert_eq!(config.logger.length, None);
+        assert_eq!(config.logger.msg_length, None);
     }
 }

--- a/tests/app_config_from_env.rs
+++ b/tests/app_config_from_env.rs
@@ -15,6 +15,8 @@ mod app_config_from_env {
         std::env::set_var("TEST_SERVICE_NAME", "TEST");
         std::env::set_var("TEST_COMPONENT_NAME", "COMPONENT_TEST");
         std::env::set_var("TEST_COMPONENT_VERSION", "1.0.0");
+        std::env::set_var("TEST_LOG_LENGTH", "300");
+        std::env::set_var("TEST_LOG_MSG_LENGTH", "0");
         std::env::set_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://0.0.0.0:4317");
         std::env::set_var("TEST_TRACE_LEVEL", "debug");
         std::env::set_var("TEST_LOG_LEVEL", "trace");
@@ -42,5 +44,27 @@ mod app_config_from_env {
         assert_eq!(logger.service_name, "TEST".to_owned());
         assert_eq!(logger.trace_level, "debug".to_owned());
         assert_eq!(logger.log_level, "trace".to_owned());
+        assert_eq!(logger.length, Some(300));
+        assert_eq!(logger.msg_length, Some(0));
+    }
+
+    #[test]
+    #[should_panic]
+    fn negative_log_length() {
+        std::env::set_var("WRONG_LOG_LENGTH", "-123");
+        let config = AppConfig::<TestStruct>::load_from([ConfigSource::EnvPrefix("TEST")])
+            .expect("Failed to build AppConfig");
+
+        assert_eq!(config.logger.length, None);
+    }
+
+    #[test]
+    #[should_panic]
+    fn wrong_log_length() {
+        std::env::set_var("WRONG_LOG_LENGTH", "1a123");
+        let config = AppConfig::<TestStruct>::load_from([ConfigSource::EnvPrefix("TEST")])
+            .expect("Failed to build AppConfig");
+
+        assert_eq!(config.logger.length, None);
     }
 }


### PR DESCRIPTION
```rust
use fregate::log_fmt::{fregate_layer, EventFormatter};
use std::str::FromStr;
use tracing::info;
use tracing_subscriber::layer::SubscriberExt;
use tracing_subscriber::util::SubscriberInitExt;
use tracing_subscriber::{registry, EnvFilter, Layer};

#[tokio::main]
async fn main() {
    let log_layer = fregate_layer(EventFormatter::new_with_limits(Some(1)));

    registry()
        .with(log_layer.with_filter(EnvFilter::from_str("info").unwrap()))
        .init();

    info!("message");
}
```
Will produce next log message:
```json
{"time":1673608228799729000,"timestamp":"2023-01-13T11:10:28.800Z","LogLevel":"INFO","target":"playground","msg":"m ..."}
```