### PR TITLE
TracingFields change insert method to take 'static lifetime values.

### DIFF
--- a/src/observability/tracing/floor_char_boundary.rs
+++ b/src/observability/tracing/floor_char_boundary.rs
@@ -1,11 +1,7 @@
-//! Since Rust will panic on this:
-//! ```no_run
-//! let a = "안녕하세요";
-//! let b = &[0..1];
-//! ```
-//! It might be useful to find char boundaries and avoid looping over each element of string.
+//! Since Rust will panic on attempt to get slice on invalid char boundaries
+//! It might be useful to find valid char boundaries and avoid looping over each element of string.
 
-/// This is a copy of floor_char_boundary fn which is [`unstable`](https://github.com/rust-lang/rust/issues/93743) now.
+/// This is a copy of floor_char_boundary fn which is [`unstable`](https://github.com/rust-lang/rust/issues/93743).
 /// Once it is stabilised this will be removed from fregate.
 pub fn floor_char_boundary(val: &str, index: usize) -> usize {
     if index >= val.len() {

--- a/src/observability/tracing/tracing_fields.rs
+++ b/src/observability/tracing/tracing_fields.rs
@@ -81,7 +81,7 @@ impl<'a> TracingFields<'a> {
         }
     }
 
-    /// Wraps value into `[Box>]` prior insertion. Overwrites value if key is present.
+    /// Wraps value into [`Box`] and insert key-value pair into the map. Overwrites value if key is present.
     pub fn insert<V: Valuable + Send + Sync + 'static>(&mut self, key: &'static str, value: V) {
         self.fields
             .insert(key, Field::ValuableOwned(Box::new(value)));
@@ -109,7 +109,7 @@ impl<'a> TracingFields<'a> {
         }
     }
 
-    /// Removes a key from the map.
+    /// Removes key from the map.
     pub fn remove_by_key(&mut self, key: &str) {
         self.fields.remove(key);
     }

--- a/tests/log_fmt.rs
+++ b/tests/log_fmt.rs
@@ -307,11 +307,11 @@ mod log_fmt_test {
         };
 
         let mut marker = TracingFields::with_capacity(4);
-        marker.insert("number", &test.numnber);
-        marker.insert("string", &test.string);
-        marker.insert("vector", &test.vector);
-        marker.insert("map", &test.map);
-        marker.insert("random_str", &"random_str");
+        marker.insert_ref("number", &test.numnber);
+        marker.insert_ref("string", &test.string);
+        marker.insert_ref("vector", &test.vector);
+        marker.insert_ref("map", &test.map);
+        marker.insert_ref("random_str", &"random_str");
 
         with_default(subscriber, || {
             tracing::info!(marker = marker.as_value(), "marker_test");

--- a/tests/traing_fields.rs
+++ b/tests/traing_fields.rs
@@ -10,13 +10,25 @@ mod tracing_fields {
 
         let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
 
-        let local = "local".to_owned();
-        val.insert("STATIC", &local);
-        val.insert(local.as_str(), &local);
         val.insert("str", &"str");
         val.insert_as_string("display_address", &socket);
         val.insert_as_debug("debug_address", &socket);
 
+        is_send(val);
+    }
+
+    #[test]
+    fn owning_data() {
+        let mut val = TracingFields::new();
+
+        let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080).to_string();
+
+        val.insert("str", &"str");
+        val.insert_as_string("1", &socket);
+        val.insert_as_debug("2", &socket);
+        val.insert_as_owned("3", socket.to_string());
+
+        drop(socket);
         is_send(val);
     }
 }

--- a/tests/traing_fields.rs
+++ b/tests/traing_fields.rs
@@ -10,7 +10,7 @@ mod tracing_fields {
 
         let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
 
-        val.insert("str", &"str");
+        val.insert_ref("str", &"str");
         val.insert_as_string("display_address", &socket);
         val.insert_as_debug("debug_address", &socket);
 
@@ -23,10 +23,10 @@ mod tracing_fields {
 
         let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080).to_string();
 
-        val.insert("str", &"str");
+        val.insert_ref("str", &"str");
         val.insert_as_string("1", &socket);
         val.insert_as_debug("2", &socket);
-        val.insert_as_owned("3", socket.to_string());
+        val.insert("3", socket.to_string());
 
         drop(socket);
         is_send(val);


### PR DESCRIPTION
Changed method for reference insertion:
```rust
TracingFields::insert_ref<V: Valuable + Send + Sync>(&mut self, key: &'static str, value: &'a V)
```
Added method for 'static lifetime variables insertion:
```
TracingFields::insert<V: Valuable + Send + Sync + 'static>(&mut self, key: &'static str, value: V)
```
Added method for merging with other:
```
TracingFields::merge<'b: 'a>(&mut self, other: TracingFields<'b>)
```
Now all keys are `&'static str`