### PR TITLE
Remove parking_lot feature from tracing-appender.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,15 +63,15 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 prost = "0.11.0"
 time = "0.3.14"
-tokio = { version = "1.0", features = ["signal"] }
+tokio = { version = "1", features = ["signal"] }
 tonic = "0.8.0"
 tower = { version = "0.4" }
 tower-http = "0.3"
 tracing = { version = "0.1.37", features = ["valuable"] }
-tracing-appender = { version = "0.2.2", features = ["parking_lot"]}
+tracing-appender = { version = "0.2.2" }
 tracing-subscriber = { version = "0.3.11", features = ["env-filter", "fmt", "time", "registry"] }
 tracing-opentelemetry = "0.18.0"
-opentelemetry = { version = "0.18.0", features = ["rt-tokio"]}
+opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.11.0" }
 opentelemetry-http = "0.7.0"
 valuable = "0.1.0"
@@ -95,7 +95,7 @@ tracing-subscriber = { version = "0.3.11", features = ["env-filter", "json", "ti
 valuable-derive = "0.1.0"
 rustls = { version = "0.20.7", features = ["tls12", "dangerous_configuration"] }
 hyper-rustls = { version = "0.23.0", default-features = false, features = ["native-tokio", "http1", "tls12"] }
-tokio = { version = "1.22.0", features = ["rt-multi-thread"] }
+tokio = { version = "1", features = ["rt-multi-thread"] }
 criterion = "0.4"
 
 [[bench]]

--- a/Review.md
+++ b/Review.md
@@ -15,7 +15,7 @@ but some are not public and included by a user
 ```toml
 fregate = { path = "../.." }
 tracing = "0.1.36"
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 prost = "0.11.0"
 tonic = "0.8.0"
 ```

--- a/examples/configuration/Cargo.toml
+++ b/examples/configuration/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 [dependencies]
 fregate = { path = "../.." }
 serde = { version = "1", features = ["derive"] }
-tokio = { version = "1.22.0", features = ["rt-multi-thread"] }
+tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/examples/grafana/Cargo.toml
+++ b/examples/grafana/Cargo.toml
@@ -17,4 +17,4 @@ resources = { path = "../examples_resources" }
 opentelemetry = { version = "0.18.0", features = ["rt-tokio", "trace"]}
 tracing-opentelemetry = "0.18.0"
 reqwest = "0.11.12"
-tokio = { version = "1.22.0", features = ["rt-multi-thread"] }
+tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/examples/health/Cargo.toml
+++ b/examples/health/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 
 [dependencies]
 fregate = { path = "../.." }
-tokio = { version = "1.22.0", features = ["rt-multi-thread"] }
+tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 
 [dependencies]
 fregate = { path = "../.." }
-tokio = { version = "1.22.0", features = ["rt-multi-thread"] }
+tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/examples/log-level-change/Cargo.toml
+++ b/examples/log-level-change/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 [dependencies]
 fregate = { path = "../.." }
 tracing-subscriber = "0.3.15"
-tokio = { version = "1.22.0", features = ["rt-multi-thread"] }
+tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/examples/metrics-callback/Cargo.toml
+++ b/examples/metrics-callback/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 [dependencies]
 fregate = { path = "../..", features = ["tokio-metrics"] }
 metrics = "0.20.1"
-tokio = { version = "1.22.0", features = ["rt-multi-thread"] }
+tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/examples/reflection/Cargo.toml
+++ b/examples/reflection/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [dependencies]
 fregate = { path = "../.." }
 resources = { path = "../examples_resources" }
-tonic-reflection = "0.5.0"
-tokio = { version = "1.22.0", features = ["rt-multi-thread"] }
+tonic-reflection = "0.6.0"
+tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/examples/tls/Cargo.toml
+++ b/examples/tls/Cargo.toml
@@ -25,7 +25,7 @@ fregate = { path = "../..", features = ["use_native_tls"] }
 #fregate = { path = "../..", features = ["use_rustls_tls12"] }
 resources = { path = "../examples_resources" }
 
-tokio = { version = "1.0", features = ["net", "rt-multi-thread"] }
+tokio = { version = "1", features = ["net", "rt-multi-thread"] }
 hyper-tls = { version = "0.5.0", optional = true }
 hyper-rustls = { version = "0.23.0", optional = true }
 rustls = { version = "0.20.7", optional = true, features = ["tls12", "dangerous_configuration"] }

--- a/examples/tonic/Cargo.toml
+++ b/examples/tonic/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 [dependencies]
 fregate = { path = "../.." }
 resources = { path = "../examples_resources" }
-tokio = { version = "1.22.0", features = ["rt-multi-thread"] }
+tokio = { version = "1", features = ["rt-multi-thread"] }


### PR DESCRIPTION
Since 1.62 rust standard library start to use futex-based lock's in Linux-based systems and `parking_lot` non actual on these versions.