### PR TITLE
Add feature util to tower-http.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fregate"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/elefant-dev/fregate-rs"
@@ -66,7 +66,7 @@ time = "0.3.14"
 tokio = { version = "1", features = ["signal"] }
 tonic = "0.8.0"
 tower = { version = "0.4" }
-tower-http = "0.3"
+tower-http = { version = "0.4.*", features = ["util"] }
 tracing = { version = "0.1.37", features = ["valuable"] }
 tracing-appender = { version = "0.2.2" }
 tracing-subscriber = { version = "0.3.11", features = ["env-filter", "fmt", "time", "registry"] }

--- a/examples/tls/Cargo.toml
+++ b/examples/tls/Cargo.toml
@@ -30,4 +30,4 @@ hyper-tls = { version = "0.5.0", optional = true }
 hyper-rustls = { version = "0.23.0", optional = true }
 rustls = { version = "0.20.7", optional = true, features = ["tls12", "dangerous_configuration"] }
 
-tonic-reflection = "0.5.0"
+tonic-reflection = "0.6.0"


### PR DESCRIPTION
`tower_http::ServiceBuilderExt` here: https://github.com/elefant-dev/fregate-rs/blob/584328fe01a0e753fd05614cc47e56f6a8c14b85/src/extensions/axum_tonic.rs#L9
under `util` feature and sometimes build can fail.
