### PR TITLE
Fix runtime error with regex 1.8.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.10.5] - 2023-04-21
+### Fixed
+- Runtime error in `tracing-subscriber` because of `regex 1.8`:
+  - https://github.com/rust-lang/regex/issues/982
+  - https://github.com/tokio-rs/tracing/issues/2565
+
 ## [0.10.3] - 2023-03-14
 ### Added
 - Reversed proxy middleware ([#170](https://github.com/elefant-dev/fregate-rs/pull/170))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
-## [0.10.5] - 2023-04-21
+## [0.10.4] - 2023-04-21
 ### Fixed
 - Runtime error in `tracing-subscriber` because of `regex 1.8`:
   - https://github.com/rust-lang/regex/issues/982

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fregate"
-version = "0.10.4"
+version = "0.10.5"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/elefant-dev/fregate-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,11 @@ use_rustls_tls12 = [
 ]
 
 [dependencies]
+# TODO: FIXME:
+# https://github.com/rust-lang/regex/issues/982
+# https://github.com/tokio-rs/tracing/issues/2565
+regex = { version = "1.6.0", default-features = false, features = ["unicode-case", "unicode-perl"] }
+
 ahash = { version = "0.8.2", optional = true }
 axum = { version = "0.6.1", features = ["headers", "http1", "http2", "json", "matched-path", "original-uri", "ws"] }
 bytes = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fregate"
-version = "0.10.5"
+version = "0.10.4"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/elefant-dev/fregate-rs"


### PR DESCRIPTION
Runtime error in `tracing-subscriber` because of `regex 1.8`:
  - https://github.com/rust-lang/regex/issues/982
  - https://github.com/tokio-rs/tracing/issues/2565