### PR TITLE
should_proxy callback might return Error

### DIFF
--- a/src/middleware/proxy_layer/layer.rs
+++ b/src/middleware/proxy_layer/layer.rs
@@ -149,7 +149,8 @@ impl<
         ShouldProxyCallback: for<'any> Fn(
                 &'any Request<TBody>,
                 &'any (),
-            ) -> Pin<Box<dyn Future<Output = bool> + Send + 'any>>
+            )
+                -> Pin<Box<dyn Future<Output = Result<bool, AxumResponse>> + Send + 'any>>
             + Send
             + Sync
             + 'static,
@@ -207,7 +208,8 @@ impl<
         ShouldProxyCallback: for<'any> Fn(
                 &'any Request<TBody>,
                 &'any TExtension,
-            ) -> Pin<Box<dyn Future<Output = bool> + Send + 'any>>
+            )
+                -> Pin<Box<dyn Future<Output = Result<bool, AxumResponse>> + Send + 'any>>
             + Send
             + Sync
             + 'static,

--- a/src/middleware/proxy_layer/shared.rs
+++ b/src/middleware/proxy_layer/shared.rs
@@ -157,8 +157,9 @@ where
     ShouldProxyCallback: for<'any> Fn(
             &'any Request<TBody>,
             &'any TExtension,
-        ) -> Pin<Box<dyn Future<Output = bool> + Send + 'any>>
-        + Send
+        ) -> Pin<
+            Box<dyn Future<Output = Result<bool, axum::response::Response>> + Send + 'any>,
+        > + Send
         + Sync
         + 'static,
     OnProxyErrorCallback:

--- a/src/observability/headers_filter.rs
+++ b/src/observability/headers_filter.rs
@@ -68,7 +68,7 @@ impl<'de> Deserialize<'de> for HeadersFilter {
 }
 
 fn from_str_to_filter(str: Option<String>) -> Filter {
-    str.map(|str| {
+    str.map_or(Filter::Set(HashSet::default()), |str| {
         let str = str.trim();
 
         if str == "*" {
@@ -81,5 +81,4 @@ fn from_str_to_filter(str: Option<String>) -> Filter {
             )
         }
     })
-    .unwrap_or(Filter::Set(HashSet::default()))
 }


### PR DESCRIPTION
When deciding if request should be proxied in some cases it is preferable to return Error right away than passing request to handlers.